### PR TITLE
Refactor: extract create_tab3 into separate module

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from mylibproject.myutils import to_percent
 from mylibproject.myutils_work_with_file import extract_data_frec_from_file
 
 from mylibproject.myutils_widgets import make_context_menu, select_path, message_log, add_hotkeys
+from tab3 import create_tab3
 
 
 def on_combo_changeX_Y_labels(combo, entry, label_size, size_combo):
@@ -495,50 +496,6 @@ def function1(log_text, path_entry):
         message_log(log_text, "Вы не выбрали путь к проетку LS-Dyna, выберите путь в ячейке выше...")
 
 
-def create_tab3(notebook):
-    # Создание третьей вкладки
-    tab3 = ttk.Frame(notebook)
-    notebook.add(tab3, text="Извлечение частотных параметров из LS-DYNA")
-    # Элементы на третьей вкладке
-    # Создаем фрейм для размещения текстового поля и кнопки
-    input_frame = ttk.Frame(tab3)
-    input_frame.place(x=10, y=10, width=1280, height=200)  # Фиксируем позицию фрейма
-
-    # Метка над текстовым полем
-    label = ttk.Label(input_frame, text="Выберите папку рабочего проекта:")
-    label.place(x=10, y=0)
-
-    # Создаем текстовое поле для ввода пути с отступом слева
-    path_entry = create_text(input_frame, method="entry", height=1, state='normal', scrollbar=False)
-    path_entry.place(x=10, y=30, width=600)  # Позиционирование текстового поля
-
-    select_button = ttk.Button(input_frame, text="Выбор папки", command=lambda: select_path(path_entry))
-    select_button.place(x=600, y=28)  # Позиционирование кнопки рядом с текстовым полем
-
-    # Фрейм для текстового поля логов и скроллбара
-    log_frame = ttk.Frame(tab3)
-    log_frame.place(x=10, y=150, width=1280, height=200)  # Позиционирование фрейма
-
-    # Метка над окном логирования
-    log_label = ttk.Label(log_frame, text="Окно логирования:")
-    log_label.pack(side=tk.TOP, anchor="w")  # Размещение метки
-
-    # Создаем текстовое поле для логов с прокруткой
-    log_text = create_text(log_frame, height=10, state='disabled', scrollbar=True)
-
-    # Кнопка "Получить данные" под текстовым полем
-    get_data_button = ttk.Button(input_frame, text="Получить данные",
-                                 command=lambda: function1(log_text=log_text, path_entry=path_entry))
-    get_data_button.place(x=300, y=60)  # Позиционирование кнопки ниже текстового пол
-
-    # Кнопка для очистки окна логирования
-    clear_button = ttk.Button(tab3, text="Очистить окно логирования", command=lambda: clear_text(log_text))
-    clear_button.place(x=10, y=360)  # Позиционирование кнопки под логом
-
-
-
-
-
 def on_combobox_event(event, *callbacks):
     """Вызывает все переданные функции-обработчики последовательно."""
     for callback in callbacks:
@@ -982,7 +939,7 @@ def main():
     create_tab1(notebook)
     notebook.add(tab2, text="Создание графиков для LS-DYNA")
 
-    create_tab3(notebook)
+    create_tab3(notebook, create_text, function1, clear_text)
 
     # Привязка обработчика закрытия окна
     root.protocol("WM_DELETE_WINDOW", lambda: on_closing(root))

--- a/tab3.py
+++ b/tab3.py
@@ -1,0 +1,48 @@
+import tkinter as tk
+from tkinter import ttk
+from mylibproject.myutils_widgets import select_path
+
+
+def create_tab3(notebook, create_text, function1, clear_text):
+    """Создает вкладку для извлечения частотных параметров из LS-DYNA."""
+    # Создание третьей вкладки
+    tab3 = ttk.Frame(notebook)
+    notebook.add(tab3, text="Извлечение частотных параметров из LS-DYNA")
+
+    # Создаем фрейм для размещения текстового поля и кнопки
+    input_frame = ttk.Frame(tab3)
+    input_frame.place(x=10, y=10, width=1280, height=200)
+
+    # Метка над текстовым полем
+    label = ttk.Label(input_frame, text="Выберите папку рабочего проекта:")
+    label.place(x=10, y=0)
+
+    # Создаем текстовое поле для ввода пути с отступом слева
+    path_entry = create_text(input_frame, method="entry", height=1, state='normal', scrollbar=False)
+    path_entry.place(x=10, y=30, width=600)
+
+    select_button = ttk.Button(input_frame, text="Выбор папки", command=lambda: select_path(path_entry))
+    select_button.place(x=600, y=28)
+
+    # Фрейм для текстового поля логов и скроллбара
+    log_frame = ttk.Frame(tab3)
+    log_frame.place(x=10, y=150, width=1280, height=200)
+
+    # Метка над окном логирования
+    log_label = ttk.Label(log_frame, text="Окно логирования:")
+    log_label.pack(side=tk.TOP, anchor="w")
+
+    # Создаем текстовое поле для логов с прокруткой
+    log_text = create_text(log_frame, height=10, state='disabled', scrollbar=True)
+
+    # Кнопка "Получить данные" под текстовым полем
+    get_data_button = ttk.Button(
+        input_frame,
+        text="Получить данные",
+        command=lambda: function1(log_text=log_text, path_entry=path_entry),
+    )
+    get_data_button.place(x=300, y=60)
+
+    # Кнопка для очистки окна логирования
+    clear_button = ttk.Button(tab3, text="Очистить окно логирования", command=lambda: clear_text(log_text))
+    clear_button.place(x=10, y=360)


### PR DESCRIPTION
## Summary
- move create_tab3 implementation into new tab3 module
- import create_tab3 from new module and pass helper functions when creating tab in main

## Testing
- `python -m py_compile main.py tab3.py`


------
https://chatgpt.com/codex/tasks/task_e_6897acb926d0832abdfc38185885bfc3