### PR TITLE
Handle non-Windows platforms in myutils.is_russian_layout

### DIFF
--- a/mylibproject/myutils.py
+++ b/mylibproject/myutils.py
@@ -1,10 +1,15 @@
 import ctypes
+import sys
 
 def to_percent(y, pos):
     return f"{y:.2f}%"  # Форматирование с двумя знаками после запятой
 
 def is_russian_layout():
     """Проверяет, активна ли русская раскладка."""
+    if not sys.platform.startswith("win"):
+        return False
+    if not hasattr(ctypes, "windll"):
+        raise AttributeError("ctypes.windll is not available on this platform")
     # Получаем текущую раскладку клавиатуры
     layout = ctypes.windll.user32.GetKeyboardLayout(0)
     return (layout & 0xFFFF) == 0x0419  # 0x0419 — это код для русской раскладки


### PR DESCRIPTION
## Summary
- add `sys.platform` check to `is_russian_layout`
- raise an informative error when `ctypes.windll` is unavailable

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897b3791558832a94ddafe5ba79cd76