### PR TITLE
fix malformed Thumbs.db ignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ venv/
 env/
 .env
 .DS_Store
-Thumbs.db-сс
+Thumbs.db


### PR DESCRIPTION
## Summary
- replace corrupted `Thumbs.db` entry in `.gitignore` with a proper rule

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897ba1e3c1c832ab2c48724fd4cef9a