### PR TITLE
Ensure Tkinter import at top for widgets utilities

### DIFF
--- a/mylibproject/myutils_widgets.py
+++ b/mylibproject/myutils_widgets.py
@@ -1,4 +1,4 @@
-import tkinter as tk
+import tkinter as tk  # Import Tkinter under alias tk
 from tkinter import filedialog
 
 from mylibproject.myutils import is_russian_layout


### PR DESCRIPTION
## Summary
- Ensure `tkinter` is imported as `tk` at the top of `myutils_widgets`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897ba2a1cec832aa1b5e4905dcbdd13