### PR TITLE
Handle missing windll in is_russian_layout

### DIFF
--- a/mylibproject/myutils.py
+++ b/mylibproject/myutils.py
@@ -5,11 +5,16 @@ def to_percent(y, pos):
     return f"{y:.2f}%"  # Форматирование с двумя знаками после запятой
 
 def is_russian_layout():
-    """Проверяет, активна ли русская раскладка."""
+    """Проверяет, активна ли русская раскладка.
+
+    Note:
+        Функция предназначена только для Windows и возвращает ``False`` на
+        других платформах или когда ``ctypes.windll`` недоступен.
+    """
     if not sys.platform.startswith("win"):
         return False
     if not hasattr(ctypes, "windll"):
-        raise AttributeError("ctypes.windll is not available on this platform")
+        return False
     # Получаем текущую раскладку клавиатуры
     layout = ctypes.windll.user32.GetKeyboardLayout(0)
     return (layout & 0xFFFF) == 0x0419  # 0x0419 — это код для русской раскладки


### PR DESCRIPTION
## Summary
- avoid AttributeError in `is_russian_layout` by returning False when `ctypes.windll` is unavailable
- document Windows-only behavior in `is_russian_layout`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897ba5dce30832aa1afb1b67fbc461f