### PR TITLE
Добавить вертикальный скролл для списка кривых

### DIFF
--- a/main.py
+++ b/main.py
@@ -522,20 +522,29 @@ def create_curve_box(input_frame, i, checkbox_var, saved_data):
                                combo_curve_typeY_type)
 
 
-def update_curves(frame, num_curves, next_frame, checkbox_var, saved_data):
-    """Обновляет кривые в соответствии с выбранным количеством и состоянием чекбокса."""
+def update_curves(frame, num_curves, next_frame, checkbox_var, saved_data, canvas=None, scrollbar=None):
+    """Обновляет кривые в соответствии с выбранным количеством и состоянием чекбокса.
+
+    При превышении доступной области отображения добавляется вертикальная прокрутка.
+    """
     # Очищаем старые виджеты
     for widget in frame.winfo_children():
         widget.destroy()
 
-    if num_curves == '':
+    if not num_curves:
+        if canvas is not None:
+            canvas.configure(scrollregion=(0, 0, 0, 0))
+            canvas.configure(height=0)
+        if scrollbar is not None:
+            scrollbar.place_forget()
+        if next_frame is not None and canvas is not None:
+            next_frame.place(x=10, y=canvas.winfo_y())
         return
-    else:
-        num_curves_int = int(num_curves)
 
-    # Меняем высоту фрейма в зависимости от количества кривых
-    frame_height = 210 * num_curves_int if checkbox_var.get() else 150 * num_curves_int
-    frame.place_configure(height=frame_height)
+    num_curves_int = int(num_curves)
+
+    # Полная высота содержимого
+    content_height = 210 * num_curves_int if checkbox_var.get() else 150 * num_curves_int
 
     # Восстанавливаем данные, если они есть
     for i in range(len(saved_data), num_curves_int):
@@ -545,7 +554,25 @@ def update_curves(frame, num_curves, next_frame, checkbox_var, saved_data):
     for i in range(1, num_curves_int + 1):
         create_curve_box(frame, i, checkbox_var, saved_data)
 
-    next_frame.place(x=10, y=frame.winfo_y() + frame_height + 10)  # Обновляем координаты следующего фрейма
+    if canvas is not None:
+        canvas.update_idletasks()
+        frame.configure(width=canvas.winfo_width(), height=content_height)
+        canvas.configure(scrollregion=(0, 0, canvas.winfo_width(), content_height))
+
+        max_canvas_height = canvas.master.winfo_height() - canvas.winfo_y() - 20
+        new_height = min(content_height, max_canvas_height)
+        canvas.configure(height=new_height)
+
+        if scrollbar is not None:
+            if content_height > new_height:
+                scrollbar.place(x=canvas.winfo_x() + canvas.winfo_width(),
+                                y=canvas.winfo_y(),
+                                height=new_height)
+            else:
+                scrollbar.place_forget()
+
+        if next_frame is not None:
+            next_frame.place(x=10, y=canvas.winfo_y() + new_height + 10)
 
 
 def save_file(entry_widget, graph_info):

--- a/tabs/tab1.py
+++ b/tabs/tab1.py
@@ -116,13 +116,21 @@ def create_tab1(notebook, create_text, update_curves, generate_graph, save_file)
     combo_curves = ttk.Combobox(input_frame, values=curve_options, state='readonly')
     combo_curves.place(x=250, y=120, width=150)
 
-    # Фрейм для полей ввода кривых
-    curves_frame = ttk.Frame(tab1)
-    curves_frame.place(x=10, y=170, width=1500, height=200)
+    # Прокручиваемая область для полей ввода кривых
+    curves_canvas = tk.Canvas(tab1)
+    curves_canvas.place(x=10, y=170, width=1460, height=0)
+
+    curves_scrollbar = ttk.Scrollbar(tab1, orient="vertical", command=curves_canvas.yview)
+    curves_canvas.configure(yscrollcommand=curves_scrollbar.set)
+    curves_scrollbar.place_forget()
+
+    curves_frame = ttk.Frame(curves_canvas)
+    curves_canvas.create_window((0, 0), window=curves_frame, anchor="nw", width=1460)
+
     combo_curves.bind(
         "<<ComboboxSelected>>",
         lambda e: update_curves(
-            curves_frame, combo_curves.get(), save_frame, checkbox_var, saved_data_curves
+            curves_frame, combo_curves.get(), save_frame, checkbox_var, saved_data_curves, curves_canvas, curves_scrollbar
         )
     )
 
@@ -170,7 +178,7 @@ def create_tab1(notebook, create_text, update_curves, generate_graph, save_file)
         text="Легенда",
         variable=checkbox_var,
         command=lambda: update_curves(
-            curves_frame, combo_curves.get(), save_frame, checkbox_var, saved_data_curves
+            curves_frame, combo_curves.get(), save_frame, checkbox_var, saved_data_curves, curves_canvas, curves_scrollbar
         )
     )
     checkbox.place(x=450, y=120)


### PR DESCRIPTION
## Summary
- Сделана область ввода кривых динамической: высота растёт до предельного размера окна
- Вертикальный скролл появляется только при переполнении списка кривых

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68982e97f300832ab7c1f3dfefd6f68d