### PR TITLE
Убрал лишние импорты из main

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,11 +8,10 @@ import logging
 
 from mylibproject.myutils import to_percent
 
-from mylibproject.myutils_widgets import make_context_menu, message_log, add_hotkeys
+from mylibproject.myutils_widgets import make_context_menu, add_hotkeys
 from tabs.tab3 import create_tab3
 from tabs.tab2 import create_tab2
 from tabs.tab1 import create_tab1
-from tabs.functions_for_tab3.processing import function1
 
 
 
@@ -167,7 +166,7 @@ def main():
     create_tab1(notebook, create_text)
     create_tab2(notebook)
 
-    create_tab3(notebook, create_text, function1, clear_text)
+    create_tab3(notebook, create_text, clear_text)
 
     # Привязка обработчика закрытия окна
     root.protocol("WM_DELETE_WINDOW", lambda: on_closing(root))

--- a/tabs/tab3.py
+++ b/tabs/tab3.py
@@ -1,8 +1,10 @@
 import tkinter as tk
 from tkinter import ttk
 from mylibproject.myutils_widgets import select_path
+from .functions_for_tab3.processing import function1
 
-def create_tab3(notebook, create_text, function1, clear_text):
+
+def create_tab3(notebook, create_text, clear_text):
     """Создает вкладку для извлечения частотных параметров из LS-DYNA."""
     # Создание третьей вкладки
     tab3 = ttk.Frame(notebook)


### PR DESCRIPTION
## Summary
- Удалён неиспользуемый `message_log` из `main.py`
- Импорт `function1` перемещён в `tabs/tab3.py`, главный файл теперь не зависит от него напрямую
- Вызов `create_tab3` обновлён под новую сигнатуру

## Testing
- `python -m py_compile main.py tabs/tab3.py`


------
https://chatgpt.com/codex/tasks/task_e_68985a6180bc832a89fb1226726fb6bf