### PR TITLE
Добавить опцию горизонтального чтения Excel

### DIFF
--- a/tabs/functions_for_tab1/curves.py
+++ b/tabs/functions_for_tab1/curves.py
@@ -1,3 +1,4 @@
+import tkinter as tk
 from tkinter import ttk
 from widgets.select_path import select_path
 
@@ -68,21 +69,43 @@ def create_curve_box(input_frame, i, checkbox_var, saved_data):
     combo_curve_typeY_type.place(x=combo_curve_typeX_type.winfo_x() + 170,
                                  y=combo_curve_type.winfo_y() + 45, width=150)  # Позиция для оси Y
 
+    horizontal_var = tk.BooleanVar(value=saved_data[i - 1].get('horizontal', False))
+    checkbox_horizontal = ttk.Checkbutton(
+        input_frame,
+        text="По-горизонтали",
+        variable=horizontal_var,
+        command=lambda: saved_data[i - 1].update({'horizontal': horizontal_var.get()})
+    )
+    checkbox_horizontal._name = f"curve_{i}_horizontal"
+    checkbox_horizontal.var = horizontal_var
+
+    def toggle_horizontal_checkbox():
+        if combo_curve_type.get() == "Excel файл":
+            checkbox_horizontal.place(x=10, y=60 + dy * (i - 1))
+        else:
+            checkbox_horizontal.place_forget()
+
     # Привязка события изменения выбора в combo_curve_type
-    combo_curve_type.bind("<<ComboboxSelected>>",
-                          lambda event: on_combobox_event(event,
-                                                          lambda e: on_combo_change_curve_type(input_frame,
-                                                                                               combo_curve_type,
-                                                                                               label_curve_typeX,
-                                                                                               combo_curve_typeX,
-                                                                                               label_curve_typeY,
-                                                                                               combo_curve_typeY,
-                                                                                               label_curve_typeX_type,
-                                                                                               combo_curve_typeX_type,
-                                                                                               label_curve_typeY_type,
-                                                                                               combo_curve_typeY_type),
-                                                          lambda e: saved_data[i - 1].update(
-                                                              {'curve_type': combo_curve_type.get()})))
+    combo_curve_type.bind(
+        "<<ComboboxSelected>>",
+        lambda event: on_combobox_event(
+            event,
+            lambda e: on_combo_change_curve_type(
+                input_frame,
+                combo_curve_type,
+                label_curve_typeX,
+                combo_curve_typeX,
+                label_curve_typeY,
+                combo_curve_typeY,
+                label_curve_typeX_type,
+                combo_curve_typeX_type,
+                label_curve_typeY_type,
+                combo_curve_typeY_type,
+            ),
+            lambda e: saved_data[i - 1].update({'curve_type': combo_curve_type.get()}),
+            lambda e: toggle_horizontal_checkbox(),
+        ),
+    )
 
     # Метка для выбора файла с кривой
     label_path = ttk.Label(input_frame, text="Выберите файл с кривой:")
@@ -107,6 +130,8 @@ def create_curve_box(input_frame, i, checkbox_var, saved_data):
         legend_entry.place(x=10, y=170 + dy * (i - 1), width=300)
         legend_entry._name = f"curve_{i}_legend"
 
+    toggle_horizontal_checkbox()
+
     return None
 
 
@@ -128,7 +153,7 @@ def update_curves(frame, num_curves, next_frame, checkbox_var, saved_data):
     # Восстанавливаем данные, если они есть
     for i in range(len(saved_data), num_curves_int):
         saved_data.append({'curve_type': "", 'path': "", 'legend': "", 'curve_typeX': "", 'curve_typeY': "",
-                           'curve_typeX_type': "", 'curve_typeY_type': ""})
+                           'curve_typeX_type': "", 'curve_typeY_type': "", 'horizontal': False})
 
     for i in range(1, num_curves_int + 1):
         create_curve_box(frame, i, checkbox_var, saved_data)

--- a/tabs/functions_for_tab1/curves_from_file/excel_file.py
+++ b/tabs/functions_for_tab1/curves_from_file/excel_file.py
@@ -13,32 +13,56 @@ def read_X_Y_from_excel(curve_info):
         suffix = path.suffix.lower()
         X_data = []
         Y_data = []
+        horizontal = curve_info.get('horizontal', False)
 
         if suffix in {'.xlsx', '.xlsm'}:
             wb = load_workbook(path, read_only=True, data_only=True)
             ws = wb.active
-            for row in ws.iter_rows(values_only=True):
-                if row is None or len(row) < 2:
-                    continue
-                x, y = row[0], row[1]
-                if x is None or y is None:
-                    continue
-                try:
-                    X_data.append(float(str(x).replace(',', '.')))
-                    Y_data.append(float(str(y).replace(',', '.')))
-                except (ValueError, TypeError):
-                    logger.error("Некорректная строка данных: %s", row)
+            if horizontal:
+                rows = list(ws.iter_rows(values_only=True))
+                if len(rows) >= 2:
+                    row_x, row_y = rows[0], rows[1]
+                    for x, y in zip(row_x, row_y):
+                        if x is None or y is None:
+                            continue
+                        try:
+                            X_data.append(float(str(x).replace(',', '.')))
+                            Y_data.append(float(str(y).replace(',', '.')))
+                        except (ValueError, TypeError):
+                            logger.error("Некорректная пара данных: %s, %s", x, y)
+            else:
+                for row in ws.iter_rows(values_only=True):
+                    if row is None or len(row) < 2:
+                        continue
+                    x, y = row[0], row[1]
+                    if x is None or y is None:
+                        continue
+                    try:
+                        X_data.append(float(str(x).replace(',', '.')))
+                        Y_data.append(float(str(y).replace(',', '.')))
+                    except (ValueError, TypeError):
+                        logger.error("Некорректная строка данных: %s", row)
         elif suffix == '.csv':
             with open(path, 'r', encoding='utf-8') as f:
                 reader = csv.reader(f)
-                for row in reader:
-                    if len(row) < 2:
-                        continue
-                    try:
-                        X_data.append(float(row[0].replace(',', '.')))
-                        Y_data.append(float(row[1].replace(',', '.')))
-                    except ValueError:
-                        logger.error("Некорректная строка данных: %s", row)
+                if horizontal:
+                    rows = list(reader)
+                    if len(rows) >= 2:
+                        for x, y in zip(rows[0], rows[1]):
+                            try:
+                                X_data.append(float(x.replace(',', '.')))
+                                Y_data.append(float(y.replace(',', '.')))
+                            except ValueError:
+                                logger.error("Некорректная пара данных: %s, %s", x, y)
+                else:
+                    for row in reader:
+                        if len(row) < 2:
+                            continue
+                        try:
+                            X_data.append(float(row[0].replace(',', '.')))
+                            Y_data.append(float(row[1].replace(',', '.')))
+                        except ValueError:
+                            logger.error("Некорректная строка данных: %s", row)
         else:
             logger.error("Неподдерживаемый формат файла: %s", suffix)
             return

--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -147,6 +147,9 @@ def generate_graph(ax, fig, canvas, path_entry_title, combo_titleX, combo_titleX
                 if widget_name == f"curve_{i}_filename":
                     curve_info['curve_file'] = widget.get()
 
+                if widget_name == f"curve_{i}_horizontal":
+                    curve_info['horizontal'] = widget.var.get()
+
                 # Проверяем наличие легенды, если отмечен чекбокс
                 if legend_checkbox.get() and widget_name == f"curve_{i}_legend":
                     curve_info['curve_legend'] = widget.get()


### PR DESCRIPTION
## Summary
- добавить чекбокс "По-горизонтали" для Excel кривых
- поддержать чтение строк Excel и CSV при активном чекбоксе

## Testing
- `python -m py_compile tabs/functions_for_tab1/curves.py tabs/functions_for_tab1/plotting.py tabs/functions_for_tab1/curves_from_file/excel_file.py`


------
https://chatgpt.com/codex/tasks/task_e_68989b1e4420832a8e39ff0612be45f3