### PR TITLE
Добавлено смещение для кривых из Excel

### DIFF
--- a/tabs/functions_for_tab1/curves.py
+++ b/tabs/functions_for_tab1/curves.py
@@ -79,11 +79,60 @@ def create_curve_box(input_frame, i, checkbox_var, saved_data):
     checkbox_horizontal._name = f"curve_{i}_horizontal"
     checkbox_horizontal.var = horizontal_var
 
+    offset_var = tk.BooleanVar(value=saved_data[i - 1].get('offset', False))
+
+    offset_x_var = tk.StringVar(value=str(saved_data[i - 1].get('offset_x', 0)))
+    offset_y_var = tk.StringVar(value=str(saved_data[i - 1].get('offset_y', 0)))
+
+    def on_offset_toggle():
+        saved_data[i - 1].update({'offset': offset_var.get()})
+        toggle_offset_widgets()
+
+    checkbox_offset = ttk.Checkbutton(
+        input_frame,
+        text="Смещение",
+        variable=offset_var,
+        command=on_offset_toggle,
+    )
+    checkbox_offset._name = f"curve_{i}_offset"
+    checkbox_offset.var = offset_var
+
+    label_offset_x = ttk.Label(input_frame, text="dX:")
+    entry_offset_x = ttk.Entry(input_frame, textvariable=offset_x_var, width=6)
+    entry_offset_x._name = f"curve_{i}_offset_x"
+
+    label_offset_y = ttk.Label(input_frame, text="dY:")
+    entry_offset_y = ttk.Entry(input_frame, textvariable=offset_y_var, width=6)
+    entry_offset_y._name = f"curve_{i}_offset_y"
+
+    offset_x_var.trace_add('write', lambda *args: saved_data[i - 1].update({'offset_x': offset_x_var.get()}))
+    offset_y_var.trace_add('write', lambda *args: saved_data[i - 1].update({'offset_y': offset_y_var.get()}))
+
     def toggle_horizontal_checkbox():
         if combo_curve_type.get() == "Excel файл":
             checkbox_horizontal.place(x=10, y=60 + dy * (i - 1))
         else:
             checkbox_horizontal.place_forget()
+
+    def toggle_offset_widgets():
+        if combo_curve_type.get() == "Excel файл":
+            checkbox_offset.place(x=150, y=60 + dy * (i - 1))
+            if offset_var.get():
+                label_offset_x.place(x=250, y=60 + dy * (i - 1))
+                entry_offset_x.place(x=280, y=60 + dy * (i - 1))
+                label_offset_y.place(x=330, y=60 + dy * (i - 1))
+                entry_offset_y.place(x=360, y=60 + dy * (i - 1))
+            else:
+                label_offset_x.place_forget()
+                entry_offset_x.place_forget()
+                label_offset_y.place_forget()
+                entry_offset_y.place_forget()
+        else:
+            checkbox_offset.place_forget()
+            label_offset_x.place_forget()
+            entry_offset_x.place_forget()
+            label_offset_y.place_forget()
+            entry_offset_y.place_forget()
 
     # Привязка события изменения выбора в combo_curve_type
     combo_curve_type.bind(
@@ -103,7 +152,7 @@ def create_curve_box(input_frame, i, checkbox_var, saved_data):
                 combo_curve_typeY_type,
             ),
             lambda e: saved_data[i - 1].update({'curve_type': combo_curve_type.get()}),
-            lambda e: toggle_horizontal_checkbox(),
+            lambda e: (toggle_horizontal_checkbox(), toggle_offset_widgets()),
         ),
     )
 
@@ -131,6 +180,7 @@ def create_curve_box(input_frame, i, checkbox_var, saved_data):
         legend_entry._name = f"curve_{i}_legend"
 
     toggle_horizontal_checkbox()
+    toggle_offset_widgets()
 
     return None
 
@@ -152,8 +202,19 @@ def update_curves(frame, num_curves, next_frame, checkbox_var, saved_data):
 
     # Восстанавливаем данные, если они есть
     for i in range(len(saved_data), num_curves_int):
-        saved_data.append({'curve_type': "", 'path': "", 'legend': "", 'curve_typeX': "", 'curve_typeY': "",
-                           'curve_typeX_type': "", 'curve_typeY_type': "", 'horizontal': False})
+        saved_data.append({
+            'curve_type': "",
+            'path': "",
+            'legend': "",
+            'curve_typeX': "",
+            'curve_typeY': "",
+            'curve_typeX_type': "",
+            'curve_typeY_type': "",
+            'horizontal': False,
+            'offset': False,
+            'offset_x': 0,
+            'offset_y': 0,
+        })
 
     for i in range(1, num_curves_int + 1):
         create_curve_box(frame, i, checkbox_var, saved_data)

--- a/tabs/functions_for_tab1/curves_from_file/excel_file.py
+++ b/tabs/functions_for_tab1/curves_from_file/excel_file.py
@@ -67,6 +67,18 @@ def read_X_Y_from_excel(curve_info):
             logger.error("Неподдерживаемый формат файла: %s", suffix)
             return
 
+        if curve_info.get('offset'):
+            try:
+                dx = float(str(curve_info.get('offset_x', 0)).replace(',', '.'))
+            except ValueError:
+                dx = 0.0
+            try:
+                dy = float(str(curve_info.get('offset_y', 0)).replace(',', '.'))
+            except ValueError:
+                dy = 0.0
+            X_data = [x + dx for x in X_data]
+            Y_data = [y + dy for y in Y_data]
+
         curve_info['X_values'] = X_data
         curve_info['Y_values'] = Y_data
     except FileNotFoundError:

--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -149,6 +149,12 @@ def generate_graph(ax, fig, canvas, path_entry_title, combo_titleX, combo_titleX
 
                 if widget_name == f"curve_{i}_horizontal":
                     curve_info['horizontal'] = widget.var.get()
+                if widget_name == f"curve_{i}_offset":
+                    curve_info['offset'] = widget.var.get()
+                if widget_name == f"curve_{i}_offset_x":
+                    curve_info['offset_x'] = widget.get()
+                if widget_name == f"curve_{i}_offset_y":
+                    curve_info['offset_y'] = widget.get()
 
                 # Проверяем наличие легенды, если отмечен чекбокс
                 if legend_checkbox.get() and widget_name == f"curve_{i}_legend":


### PR DESCRIPTION
## Summary
- Позволяет задавать смещение по X и Y для Excel-кривых через чекбокс
- Применяет указанное смещение при чтении данных и построении графика

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898a0dbda70832a89a07c9308737b5f