### PR TITLE
Добавлена поддержка комбинированного источника данных для кривых

### DIFF
--- a/tabs/functions_for_tab1/curves_from_file/__init__.py
+++ b/tabs/functions_for_tab1/curves_from_file/__init__.py
@@ -2,10 +2,12 @@ from .frequency_analysis import read_X_Y_from_frequency_analysis
 from .text_file import read_X_Y_from_text_file
 from .ls_dyna_file import read_X_Y_from_ls_dyna
 from .excel_file import read_X_Y_from_excel
+from .combined_curve import read_X_Y_from_combined
 
 __all__ = [
     "read_X_Y_from_frequency_analysis",
     "read_X_Y_from_text_file",
     "read_X_Y_from_ls_dyna",
     "read_X_Y_from_excel",
+    "read_X_Y_from_combined",
 ]

--- a/tabs/functions_for_tab1/curves_from_file/combined_curve.py
+++ b/tabs/functions_for_tab1/curves_from_file/combined_curve.py
@@ -1,0 +1,63 @@
+import logging
+from .frequency_analysis import read_X_Y_from_frequency_analysis
+from .text_file import read_X_Y_from_text_file
+from .ls_dyna_file import read_X_Y_from_ls_dyna
+from .excel_file import read_X_Y_from_excel
+
+logger = logging.getLogger(__name__)
+
+
+def _read_axis(axis_info):
+    """Считывает данные для одной оси из указанного источника."""
+    source_type = axis_info.get("source")
+    tmp_info = {"curve_file": axis_info.get("curve_file", "")}
+
+    if source_type == "Частотный анализ":
+        tmp_info.update({
+            "curve_typeXF": axis_info.get("parameter", ""),
+            "curve_typeYF": axis_info.get("parameter", ""),
+            "curve_typeXF_type": axis_info.get("direction", ""),
+            "curve_typeYF_type": axis_info.get("direction", ""),
+        })
+        read_X_Y_from_frequency_analysis(tmp_info)
+        return tmp_info.get("X_values", [])
+
+    if source_type == "Текстовой файл":
+        read_X_Y_from_text_file(tmp_info)
+        column = axis_info.get("column", 0)
+        return tmp_info.get("X_values", []) if column == 0 else tmp_info.get("Y_values", [])
+
+    if source_type == "Файл кривой LS-Dyna":
+        read_X_Y_from_ls_dyna(tmp_info)
+        column = axis_info.get("column", 0)
+        return tmp_info.get("X_values", []) if column == 0 else tmp_info.get("Y_values", [])
+
+    if source_type == "Excel файл":
+        tmp_info.update({
+            "horizontal": axis_info.get("horizontal", False),
+            "use_offset": axis_info.get("use_offset", False),
+            "offset_horizontal": axis_info.get("offset_horizontal", 0),
+            "offset_vertical": axis_info.get("offset_vertical", 0),
+            "use_ranges": axis_info.get("use_ranges", False),
+            "range_x": axis_info.get("range_x", ""),
+            "range_y": axis_info.get("range_y", ""),
+        })
+        read_X_Y_from_excel(tmp_info)
+        column = axis_info.get("column", 0)
+        return tmp_info.get("X_values", []) if column == 0 else tmp_info.get("Y_values", [])
+
+    logger.error("Неизвестный источник данных: %s", source_type)
+    return []
+
+
+def read_X_Y_from_combined(curve_info):
+    """Формирует точки (Xi, Yi) из разных источников данных.
+
+    Ожидается, что в ``curve_info`` находятся два словаря ``X_source`` и
+    ``Y_source`` с описанием источника для соответствующей оси.
+    """
+    x_vals = _read_axis(curve_info.get("X_source", {}))
+    y_vals = _read_axis(curve_info.get("Y_source", {}))
+    n = min(len(x_vals), len(y_vals))
+    curve_info["X_values"] = x_vals[:n]
+    curve_info["Y_values"] = y_vals[:n]

--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -7,6 +7,7 @@ from .curves_from_file import (
     read_X_Y_from_text_file,
     read_X_Y_from_ls_dyna,
     read_X_Y_from_excel,
+    read_X_Y_from_combined,
 )
 
 
@@ -100,6 +101,8 @@ def get_X_Y_data(curve_info):
         read_X_Y_from_ls_dyna(curve_info)
     elif curve_info['curve_type'] == 'Excel файл':
         read_X_Y_from_excel(curve_info)
+    elif curve_info['curve_type'] == 'Комбинированный':
+        read_X_Y_from_combined(curve_info)
 
 
 def generate_graph(ax, fig, canvas, path_entry_title, combo_titleX, combo_titleX_size, combo_titleY, combo_titleY_size,


### PR DESCRIPTION
## Summary
- Добавлен модуль чтения комбинированных кривых, позволяющий строить графики из разных источников данных по осям X и Y.
- Расширен список экспортируемых функций и логика построения графиков для нового типа кривой.

## Testing
- `python -m py_compile tabs/functions_for_tab1/curves_from_file/combined_curve.py tabs/functions_for_tab1/plotting.py tabs/functions_for_tab1/curves_from_file/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6898beb9eb04832a89c732d00d2446b4