### PR TITLE
Добавлено меню выбора типа данных для комбинированной кривой

### DIFF
--- a/tabs/functions_for_tab1/curves.py
+++ b/tabs/functions_for_tab1/curves.py
@@ -49,6 +49,31 @@ def create_curve_box(input_frame, i, checkbox_var, saved_data):
                                           state='readonly')
     combo_curve_typeY_type._name = f"curve_{i}_typeYFtype"
 
+    # Элементы для комбинированного типа
+    label_source_X = ttk.Label(input_frame, text="Выберите тип для X:")
+    combo_source_X = ttk.Combobox(
+        input_frame,
+        values=["Частотный анализ", "Текстовой файл", "Файл кривой LS-Dyna", "Excel файл"],
+        state='readonly'
+    )
+    combo_source_X._name = f"curve_{i}_X_source"
+    combo_source_X.bind(
+        "<<ComboboxSelected>>",
+        lambda e: saved_data[i - 1].setdefault('X_source', {}).update({'source': combo_source_X.get()})
+    )
+
+    label_source_Y = ttk.Label(input_frame, text="Выберите тип для данных Y:")
+    combo_source_Y = ttk.Combobox(
+        input_frame,
+        values=["Частотный анализ", "Текстовой файл", "Файл кривой LS-Dyna", "Excel файл"],
+        state='readonly'
+    )
+    combo_source_Y._name = f"curve_{i}_Y_source"
+    combo_source_Y.bind(
+        "<<ComboboxSelected>>",
+        lambda e: saved_data[i - 1].setdefault('Y_source', {}).update({'source': combo_source_Y.get()})
+    )
+
     # Установка позиций для параметров X и Y
     input_frame.update_idletasks()
     label_curve_typeX.place(x=combo_curve_type.winfo_x() + 170,
@@ -204,6 +229,10 @@ def create_curve_box(input_frame, i, checkbox_var, saved_data):
                 combo_curve_typeX_type,
                 label_curve_typeY_type,
                 combo_curve_typeY_type,
+                label_source_X,
+                combo_source_X,
+                label_source_Y,
+                combo_source_Y,
             ),
             lambda e: saved_data[i - 1].update({'curve_type': combo_curve_type.get()}),
             lambda e: toggle_excel_options(),
@@ -258,7 +287,8 @@ def update_curves(frame, num_curves, next_frame, checkbox_var, saved_data):
         saved_data.append({'curve_type': "", 'path': "", 'legend': "", 'curve_typeX': "", 'curve_typeY': "",
                            'curve_typeX_type': "", 'curve_typeY_type': "", 'horizontal': False,
                            'use_offset': False, 'offset_horizontal': 0, 'offset_vertical': 0,
-                           'use_ranges': False, 'range_x': '', 'range_y': ''})
+                           'use_ranges': False, 'range_x': '', 'range_y': '',
+                           'X_source': {}, 'Y_source': {}})
 
     for i in range(1, num_curves_int + 1):
         create_curve_box(frame, i, checkbox_var, saved_data)

--- a/tabs/functions_for_tab1/events.py
+++ b/tabs/functions_for_tab1/events.py
@@ -13,7 +13,8 @@ def on_combobox_event(event, *callbacks):
 
 def on_combo_change_curve_type(frame, combo, label_curve_typeX, combo_curve_typeX, label_curve_typeY, combo_curve_typeY,
                                label_curve_typeX_type, combo_curve_typeX_type, label_curve_typeY_type,
-                               combo_curve_typeY_type):
+                               combo_curve_typeY_type, label_source_X, combo_source_X,
+                               label_source_Y, combo_source_Y):
     if combo.get() == "Частотный анализ":
         if not label_curve_typeX.winfo_viewable():  # Проверяем, отображается ли виджет
             frame.update_idletasks()
@@ -35,6 +36,31 @@ def on_combo_change_curve_type(frame, combo, label_curve_typeX, combo_curve_type
                                          y=combo.winfo_y() + 25)  # Отступ от параметра X
             combo_curve_typeY_type.place(x=combo_curve_typeX_type.winfo_x() + 170,
                                          y=combo.winfo_y() + 45, width=150)  # Позиция для Y
+        label_source_X.place_forget()
+        combo_source_X.place_forget()
+        label_source_Y.place_forget()
+        combo_source_Y.place_forget()
+    elif combo.get() == "Комбинированный":
+        label_curve_typeX.place_forget()
+        combo_curve_typeX.place_forget()
+        label_curve_typeY.place_forget()
+        combo_curve_typeY.place_forget()
+        label_curve_typeX_type.place_forget()
+        combo_curve_typeX_type.place_forget()
+        label_curve_typeY_type.place_forget()
+        combo_curve_typeY_type.place_forget()
+
+        if not label_source_X.winfo_viewable():
+            frame.update_idletasks()
+            label_source_X.place(x=combo.winfo_x() + 170,
+                                 y=combo.winfo_y() - 20)
+            combo_source_X.place(x=combo.winfo_x() + 170,
+                                 y=combo.winfo_y(), width=150)
+            frame.update_idletasks()
+            label_source_Y.place(x=combo_source_X.winfo_x() + 170,
+                                 y=combo.winfo_y() - 20)
+            combo_source_Y.place(x=combo_source_X.winfo_x() + 170,
+                                 y=combo.winfo_y(), width=150)
     else:
         label_curve_typeX.place_forget()
         combo_curve_typeX.place_forget()
@@ -44,3 +70,7 @@ def on_combo_change_curve_type(frame, combo, label_curve_typeX, combo_curve_type
         combo_curve_typeX_type.place_forget()
         label_curve_typeY_type.place_forget()
         combo_curve_typeY_type.place_forget()
+        label_source_X.place_forget()
+        combo_source_X.place_forget()
+        label_source_Y.place_forget()
+        combo_source_Y.place_forget()

--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -146,9 +146,18 @@ def generate_graph(ax, fig, canvas, path_entry_title, combo_titleX, combo_titleX
                     elif widget_name == f"curve_{i}_typeYFtype":
                         curve_info['curve_typeYF_type'] = widget.get()
 
+                if widget_name == f"curve_{i}_X_source":
+                    curve_info.setdefault('X_source', {}).update({'source': widget.get()})
+                elif widget_name == f"curve_{i}_Y_source":
+                    curve_info.setdefault('Y_source', {}).update({'source': widget.get()})
+
                 # Получаем имя файла для каждой кривой
                 if widget_name == f"curve_{i}_filename":
                     curve_info['curve_file'] = widget.get()
+                    if 'X_source' in curve_info:
+                        curve_info['X_source'].setdefault('curve_file', widget.get())
+                    if 'Y_source' in curve_info:
+                        curve_info['Y_source'].setdefault('curve_file', widget.get())
 
                 if widget_name == f"curve_{i}_horizontal":
                     curve_info['horizontal'] = widget.var.get()


### PR DESCRIPTION
## Summary
- Добавлено всплывающее меню выбора источников данных X и Y при выборе комбинированного типа кривой
- Реализовано переключение между параметрами частотного анализа и комбинированного типа
- Сохранение выбранных типов источников и их обработка при генерации графика

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898c50de2cc832a8157875a388d9e4e