### PR TITLE
Отдельные пути для комбинированных кривых по осям

### DIFF
--- a/tabs/functions_for_tab1/curves.py
+++ b/tabs/functions_for_tab1/curves.py
@@ -233,6 +233,15 @@ def create_curve_box(input_frame, i, checkbox_var, saved_data):
                 combo_source_X,
                 label_source_Y,
                 combo_source_Y,
+                label_path,
+                path_entry,
+                select_button,
+                label_path_X,
+                path_entry_X,
+                select_button_X,
+                label_path_Y,
+                path_entry_Y,
+                select_button_Y,
             ),
             lambda e: saved_data[i - 1].update({'curve_type': combo_curve_type.get()}),
             lambda e: toggle_excel_options(),
@@ -250,9 +259,58 @@ def create_curve_box(input_frame, i, checkbox_var, saved_data):
     path_entry._name = f"curve_{i}_filename"
 
     # Кнопка для выбора файла
-    select_button = ttk.Button(input_frame, text="Выбор файла",
-                               command=lambda: select_path(path_entry, path_type='file', saved_data=saved_data[i - 1]))
+    select_button = ttk.Button(
+        input_frame,
+        text="Выбор файла",
+        command=lambda: select_path(path_entry, path_type='file', saved_data=saved_data[i - 1])
+    )
     select_button.place(x=620, y=108 + dy * (i - 1))
+
+    # Отдельные поля для комбинированного типа
+    label_path_X = ttk.Label(input_frame, text="Файл для X:")
+    label_path_X.place(x=10, y=90 + dy * (i - 1))
+    path_entry_X = create_text(input_frame, method="entry", height=1, state='normal', scrollbar=False)
+    path_entry_X.place(x=10, y=110 + dy * (i - 1), width=600)
+    path_entry_X._name = f"curve_{i}_filename_X"
+    path_entry_X.bind(
+        '<KeyRelease>',
+        lambda e: saved_data[i - 1].setdefault('X_source', {}).update({'curve_file': path_entry_X.get()})
+    )
+    select_button_X = ttk.Button(
+        input_frame,
+        text="Выбор файла",
+        command=lambda: (
+            select_path(path_entry_X, path_type='file'),
+            saved_data[i - 1].setdefault('X_source', {}).update({'curve_file': path_entry_X.get()})
+        )
+    )
+    select_button_X.place(x=620, y=108 + dy * (i - 1))
+
+    label_path_Y = ttk.Label(input_frame, text="Файл для Y:")
+    label_path_Y.place(x=10, y=140 + dy * (i - 1))
+    path_entry_Y = create_text(input_frame, method="entry", height=1, state='normal', scrollbar=False)
+    path_entry_Y.place(x=10, y=160 + dy * (i - 1), width=600)
+    path_entry_Y._name = f"curve_{i}_filename_Y"
+    path_entry_Y.bind(
+        '<KeyRelease>',
+        lambda e: saved_data[i - 1].setdefault('Y_source', {}).update({'curve_file': path_entry_Y.get()})
+    )
+    select_button_Y = ttk.Button(
+        input_frame,
+        text="Выбор файла",
+        command=lambda: (
+            select_path(path_entry_Y, path_type='file'),
+            saved_data[i - 1].setdefault('Y_source', {}).update({'curve_file': path_entry_Y.get()})
+        )
+    )
+    select_button_Y.place(x=620, y=158 + dy * (i - 1))
+
+    label_path_X.place_forget()
+    path_entry_X.place_forget()
+    select_button_X.place_forget()
+    label_path_Y.place_forget()
+    path_entry_Y.place_forget()
+    select_button_Y.place_forget()
 
     # Если чекбокс легенды отмечен, добавляем поле для легенды
     if checkbox_var.get():

--- a/tabs/functions_for_tab1/events.py
+++ b/tabs/functions_for_tab1/events.py
@@ -14,7 +14,10 @@ def on_combobox_event(event, *callbacks):
 def on_combo_change_curve_type(frame, combo, label_curve_typeX, combo_curve_typeX, label_curve_typeY, combo_curve_typeY,
                                label_curve_typeX_type, combo_curve_typeX_type, label_curve_typeY_type,
                                combo_curve_typeY_type, label_source_X, combo_source_X,
-                               label_source_Y, combo_source_Y):
+                               label_source_Y, combo_source_Y,
+                               label_path, path_entry, select_button,
+                               label_path_X, path_entry_X, select_button_X,
+                               label_path_Y, path_entry_Y, select_button_Y):
     if combo.get() == "Частотный анализ":
         if not label_curve_typeX.winfo_viewable():  # Проверяем, отображается ли виджет
             frame.update_idletasks()
@@ -40,6 +43,16 @@ def on_combo_change_curve_type(frame, combo, label_curve_typeX, combo_curve_type
         combo_source_X.place_forget()
         label_source_Y.place_forget()
         combo_source_Y.place_forget()
+
+        label_path.place(x=label_path.winfo_x(), y=label_path.winfo_y())
+        path_entry.place(x=path_entry.winfo_x(), y=path_entry.winfo_y(), width=path_entry.winfo_width())
+        select_button.place(x=select_button.winfo_x(), y=select_button.winfo_y())
+        label_path_X.place_forget()
+        path_entry_X.place_forget()
+        select_button_X.place_forget()
+        label_path_Y.place_forget()
+        path_entry_Y.place_forget()
+        select_button_Y.place_forget()
     elif combo.get() == "Комбинированный":
         label_curve_typeX.place_forget()
         combo_curve_typeX.place_forget()
@@ -49,6 +62,10 @@ def on_combo_change_curve_type(frame, combo, label_curve_typeX, combo_curve_type
         combo_curve_typeX_type.place_forget()
         label_curve_typeY_type.place_forget()
         combo_curve_typeY_type.place_forget()
+
+        label_path.place_forget()
+        path_entry.place_forget()
+        select_button.place_forget()
 
         if not label_source_X.winfo_viewable():
             frame.update_idletasks()
@@ -61,6 +78,14 @@ def on_combo_change_curve_type(frame, combo, label_curve_typeX, combo_curve_type
                                  y=combo.winfo_y() - 20)
             combo_source_Y.place(x=combo_source_X.winfo_x() + 170,
                                  y=combo.winfo_y(), width=150)
+
+        frame.update_idletasks()
+        label_path_X.place(x=label_path.winfo_x(), y=label_path.winfo_y())
+        path_entry_X.place(x=path_entry.winfo_x(), y=path_entry.winfo_y(), width=path_entry.winfo_width())
+        select_button_X.place(x=select_button.winfo_x(), y=select_button.winfo_y())
+        label_path_Y.place(x=label_path.winfo_x(), y=label_path.winfo_y() + 50)
+        path_entry_Y.place(x=path_entry.winfo_x(), y=path_entry.winfo_y() + 50, width=path_entry.winfo_width())
+        select_button_Y.place(x=select_button.winfo_x(), y=select_button.winfo_y() + 50)
     else:
         label_curve_typeX.place_forget()
         combo_curve_typeX.place_forget()
@@ -74,3 +99,13 @@ def on_combo_change_curve_type(frame, combo, label_curve_typeX, combo_curve_type
         combo_source_X.place_forget()
         label_source_Y.place_forget()
         combo_source_Y.place_forget()
+
+        label_path.place(x=label_path.winfo_x(), y=label_path.winfo_y())
+        path_entry.place(x=path_entry.winfo_x(), y=path_entry.winfo_y(), width=path_entry.winfo_width())
+        select_button.place(x=select_button.winfo_x(), y=select_button.winfo_y())
+        label_path_X.place_forget()
+        path_entry_X.place_forget()
+        select_button_X.place_forget()
+        label_path_Y.place_forget()
+        path_entry_Y.place_forget()
+        select_button_Y.place_forget()

--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -158,6 +158,10 @@ def generate_graph(ax, fig, canvas, path_entry_title, combo_titleX, combo_titleX
                         curve_info['X_source'].setdefault('curve_file', widget.get())
                     if 'Y_source' in curve_info:
                         curve_info['Y_source'].setdefault('curve_file', widget.get())
+                elif widget_name == f"curve_{i}_filename_X":
+                    curve_info.setdefault('X_source', {}).setdefault('curve_file', widget.get())
+                elif widget_name == f"curve_{i}_filename_Y":
+                    curve_info.setdefault('Y_source', {}).setdefault('curve_file', widget.get())
 
                 if widget_name == f"curve_{i}_horizontal":
                     curve_info['horizontal'] = widget.var.get()


### PR DESCRIPTION
## Summary
- добавить поля "Файл для X" и "Файл для Y" при выборе типа кривой "Комбинированный"
- обновить обработчик смены типа кривой для переключения между полями
- учитывать отдельные пути X/Y при чтении данных для графика

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898cceed740832aa747dddbeaf898ff