### PR TITLE
Исправление чтения осей для комбинированных кривых

### DIFF
--- a/tabs/functions_for_tab1/curves_from_file/combined_curve.py
+++ b/tabs/functions_for_tab1/curves_from_file/combined_curve.py
@@ -7,8 +7,11 @@ from .excel_file import read_X_Y_from_excel
 logger = logging.getLogger(__name__)
 
 
-def _read_axis(axis_info):
-    """Считывает данные для одной оси из указанного источника."""
+def _read_axis(axis_info, column=0):
+    """Считывает данные для одной оси из указанного источника.
+
+    Параметр ``column`` задаёт требуемую ось: ``0`` для X, ``1`` для Y.
+    """
     source_type = axis_info.get("source")
     tmp_info = {"curve_file": axis_info.get("curve_file", "")}
 
@@ -20,16 +23,14 @@ def _read_axis(axis_info):
             "curve_typeYF_type": axis_info.get("direction", ""),
         })
         read_X_Y_from_frequency_analysis(tmp_info)
-        return tmp_info.get("X_values", [])
+        return tmp_info.get("X_values", []) if column == 0 else tmp_info.get("Y_values", [])
 
     if source_type == "Текстовой файл":
         read_X_Y_from_text_file(tmp_info)
-        column = axis_info.get("column", 0)
         return tmp_info.get("X_values", []) if column == 0 else tmp_info.get("Y_values", [])
 
     if source_type == "Файл кривой LS-Dyna":
         read_X_Y_from_ls_dyna(tmp_info)
-        column = axis_info.get("column", 0)
         return tmp_info.get("X_values", []) if column == 0 else tmp_info.get("Y_values", [])
 
     if source_type == "Excel файл":
@@ -43,7 +44,6 @@ def _read_axis(axis_info):
             "range_y": axis_info.get("range_y", ""),
         })
         read_X_Y_from_excel(tmp_info)
-        column = axis_info.get("column", 0)
         return tmp_info.get("X_values", []) if column == 0 else tmp_info.get("Y_values", [])
 
     logger.error("Неизвестный источник данных: %s", source_type)
@@ -56,8 +56,8 @@ def read_X_Y_from_combined(curve_info):
     Ожидается, что в ``curve_info`` находятся два словаря ``X_source`` и
     ``Y_source`` с описанием источника для соответствующей оси.
     """
-    x_vals = _read_axis(curve_info.get("X_source", {}))
-    y_vals = _read_axis(curve_info.get("Y_source", {}))
+    x_vals = _read_axis(curve_info.get("X_source", {}), column=0)
+    y_vals = _read_axis(curve_info.get("Y_source", {}), column=1)
     n = min(len(x_vals), len(y_vals))
     curve_info["X_values"] = x_vals[:n]
     curve_info["Y_values"] = y_vals[:n]


### PR DESCRIPTION
## Summary
- Передан признак оси в `_read_axis`, обеспечив выбор X или Y при любых источниках
- В `read_X_Y_from_combined` добавлена передача нужного столбца для каждой оси

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898e25bc3d0832ab138660e0a25a5ca