### PR TITLE
Поддержка одиночных диапазонов для Excel

### DIFF
--- a/tabs/functions_for_tab1/curves_from_file/combined_curve.py
+++ b/tabs/functions_for_tab1/curves_from_file/combined_curve.py
@@ -42,9 +42,13 @@ def _read_axis(axis_info, column=0):
             "offset_horizontal": axis_info.get("offset_horizontal", 0),
             "offset_vertical": axis_info.get("offset_vertical", 0),
             "use_ranges": axis_info.get("use_ranges", False),
-            "range_x": axis_info.get("range_x", ""),
-            "range_y": axis_info.get("range_y", ""),
         })
+        if column == 0:
+            tmp_info["range_x"] = axis_info.get("range_x", "")
+            tmp_info["range_y"] = ""
+        else:
+            tmp_info["range_x"] = ""
+            tmp_info["range_y"] = axis_info.get("range_y", "")
         read_X_Y_from_excel(tmp_info)
         return tmp_info.get("X_values", []) if column == 0 else tmp_info.get("Y_values", [])
 

--- a/tests/test_excel_single_range.py
+++ b/tests/test_excel_single_range.py
@@ -1,0 +1,26 @@
+import tempfile
+import sys
+from pathlib import Path
+from openpyxl import Workbook
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from tabs.functions_for_tab1.curves_from_file.excel_file import read_X_Y_from_excel
+
+
+def test_read_single_x_range():
+    wb = Workbook()
+    ws = wb.active
+    ws['A1'] = 1
+    ws['A2'] = 2
+    ws['A3'] = 3
+    with tempfile.NamedTemporaryFile(suffix='.xlsx') as tmp:
+        wb.save(tmp.name)
+        info = {
+            'curve_file': tmp.name,
+            'use_ranges': True,
+            'range_x': 'A1:A3',
+            'range_y': '',
+        }
+        read_X_Y_from_excel(info)
+        assert info['X_values'] == [1.0, 2.0, 3.0]
+        assert info['Y_values'] == []


### PR DESCRIPTION
## Summary
- Allow reading of Excel/CSV ranges when only X or Y is specified
- Adjust combined curve loader to pass single-axis ranges
- Add test verifying reading a single column from an Excel range

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898f9bf79f4832aae3b3b89c5e043b9