### PR TITLE
Убрать pack из create_text и обновить размещение

### DIFF
--- a/tabs/tab3.py
+++ b/tabs/tab3.py
@@ -32,10 +32,12 @@ def create_tab3(notebook):
 
     # Метка над окном логирования
     log_label = ttk.Label(log_frame, text="Окно логирования:")
-    log_label.pack(side=tk.TOP, anchor="w")
+    log_label.place(x=0, y=0)
 
     # Создаем текстовое поле для логов с прокруткой
-    log_text = create_text(log_frame, height=10, state='disabled', scrollbar=True)
+    log_text, log_scrollbar = create_text(log_frame, height=10, state='disabled', scrollbar=True)
+    log_text.place(x=0, y=20, width=1260, height=180)
+    log_scrollbar.place(x=1260, y=20, width=20, height=180)
 
     # Кнопка "Получить данные" под текстовым полем
     get_data_button = ttk.Button(

--- a/widgets/text_widget.py
+++ b/widgets/text_widget.py
@@ -9,11 +9,9 @@ def create_text(parent, method='text', height=10, wrap='word', state='normal', s
     """Создает текстовый или строковый виджет с необязательной прокруткой."""
     if method == 'entry':
         text_widget = tk.Entry(parent, state=state)
-        text_widget.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
 
     elif method == 'text':
         text_widget = tk.Text(parent, height=height, wrap=wrap, state=state)
-        text_widget.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         if max_lines > 0:
             def limit_text_lines(text_widget, max_lines):
                 def check_lines(event):
@@ -31,21 +29,22 @@ def create_text(parent, method='text', height=10, wrap='word', state='normal', s
             def bind_scrollbar(log_text, log_scrollbar):
                 def update_scrollbar(log_text, log_scrollbar):
                     log_scrollbar.config(command=log_text.yview)
-                    log_text['yscrollcommand'] = log_scrollbar.set
+                    log_text["yscrollcommand"] = log_scrollbar.set
 
                 log_text.bind("<KeyRelease>", lambda event: update_scrollbar(log_text, log_scrollbar))
                 log_text.bind("<MouseWheel>", lambda event: update_scrollbar(log_text, log_scrollbar))
                 log_text.bind("<Configure>", lambda event: update_scrollbar(log_text, log_scrollbar))
 
             text_scrollbar = ttk.Scrollbar(parent, command=text_widget.yview)
-            text_scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
-            text_widget['yscrollcommand'] = text_scrollbar.set
+            text_widget["yscrollcommand"] = text_scrollbar.set
             bind_scrollbar(text_widget, text_scrollbar)
     else:
         raise ValueError("Некорректное значение параметра method. Должно быть 'entry' или 'text'.")
 
     make_context_menu(text_widget)
     add_hotkeys(text_widget)
+    if scrollbar and method == "text":
+        return text_widget, text_scrollbar
     return text_widget
 
 


### PR DESCRIPTION
## Summary
- Удалены вызовы `pack()` из `widgets/text_widget.create_text`
- Возврат пары `(текст, скроллбар)` при `scrollbar=True`
- Приведен `tab3` к явному размещению элементов через `place`

## Testing
- `pytest -q`
- `python main.py` (ошибка: no display name and no $DISPLAY environment variable)


------
https://chatgpt.com/codex/tasks/task_e_68998f23a6d0832a8cd7736f1e54b182