### PR TITLE
fix: support column selection for combined curves

### DIFF
--- a/tabs/functions_for_tab1/curves.py
+++ b/tabs/functions_for_tab1/curves.py
@@ -121,6 +121,7 @@ def create_curve_box(input_frame, i, checkbox_var, saved_data):
             input_frame.update_idletasks()
             label_column_X.place(x=combo_source_X.winfo_x(), y=combo_source_X.winfo_y() + 30)
             combo_column_X.place(x=combo_source_X.winfo_x(), y=combo_source_X.winfo_y() + 50, width=150)
+            saved_data[i - 1].setdefault('X_source', {}).setdefault('column', 0)
         elif source == "Excel файл":
             input_frame.update_idletasks()
             label_range_Xc.place(x=combo_source_X.winfo_x(), y=combo_source_X.winfo_y() + 30)
@@ -207,6 +208,7 @@ def create_curve_box(input_frame, i, checkbox_var, saved_data):
             input_frame.update_idletasks()
             label_column_Y.place(x=combo_source_Y.winfo_x(), y=combo_source_Y.winfo_y() + 30)
             combo_column_Y.place(x=combo_source_Y.winfo_x(), y=combo_source_Y.winfo_y() + 50, width=150)
+            saved_data[i - 1].setdefault('Y_source', {}).setdefault('column', 1)
         elif source == "Excel файл":
             input_frame.update_idletasks()
             label_range_Yc.place(x=combo_source_Y.winfo_x(), y=combo_source_Y.winfo_y() + 30)

--- a/tabs/functions_for_tab1/curves_from_file/combined_curve.py
+++ b/tabs/functions_for_tab1/curves_from_file/combined_curve.py
@@ -7,6 +7,31 @@ from .excel_file import read_X_Y_from_excel
 logger = logging.getLogger(__name__)
 
 
+def _column_to_index(value, default):
+    """Преобразует значение столбца в индекс 0/1.
+
+    Пользователь может сохранить выбор как число или как строку
+    ("X"/"Y"). Эта функция приводит такое значение к корректному
+    целому индексу. В случае ошибки возвращается значение по
+    умолчанию ``default``.
+    """
+
+    if isinstance(value, str):
+        val = value.strip().upper()
+        if val in {"X", "0"}:
+            return 0
+        if val in {"Y", "1"}:
+            return 1
+        try:
+            return int(val)
+        except ValueError:
+            return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _read_axis(axis_info, column=0):
     """Считывает данные для одной оси из указанного источника.
 
@@ -27,12 +52,12 @@ def _read_axis(axis_info, column=0):
 
     if source_type == "Текстовой файл":
         read_X_Y_from_text_file(tmp_info)
-        col = axis_info.get("column", column)
+        col = _column_to_index(axis_info.get("column"), column)
         return tmp_info.get("X_values", []) if col == 0 else tmp_info.get("Y_values", [])
 
     if source_type == "Файл кривой LS-Dyna":
         read_X_Y_from_ls_dyna(tmp_info)
-        col = axis_info.get("column", column)
+        col = _column_to_index(axis_info.get("column"), column)
         return tmp_info.get("X_values", []) if col == 0 else tmp_info.get("Y_values", [])
 
     if source_type == "Excel файл":

--- a/tests/test_combined_text_ls_dyna_columns.py
+++ b/tests/test_combined_text_ls_dyna_columns.py
@@ -1,0 +1,51 @@
+import tempfile
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from tabs.functions_for_tab1.curves_from_file.combined_curve import read_X_Y_from_combined
+
+
+def _create_temp_file(content: str):
+    tmp = tempfile.NamedTemporaryFile('w+', delete=False)
+    tmp.write(content)
+    tmp.flush()
+    return tmp
+
+
+def test_text_file_column_selection():
+    tmp = _create_temp_file('1 10\n2 20\n3 30\n')
+    curve_info = {
+        'X_source': {
+            'source': 'Текстовой файл',
+            'curve_file': tmp.name,
+            'column': 1,
+        },
+        'Y_source': {
+            'source': 'Текстовой файл',
+            'curve_file': tmp.name,
+            'column': 0,
+        },
+    }
+    read_X_Y_from_combined(curve_info)
+    assert curve_info['X_values'] == [10.0, 20.0, 30.0]
+    assert curve_info['Y_values'] == [1.0, 2.0, 3.0]
+
+
+def test_lsdyna_file_column_selection():
+    tmp = _create_temp_file('1 10\n2 20\n3 30\n')
+    curve_info = {
+        'X_source': {
+            'source': 'Файл кривой LS-Dyna',
+            'curve_file': tmp.name,
+            'column': 1,
+        },
+        'Y_source': {
+            'source': 'Файл кривой LS-Dyna',
+            'curve_file': tmp.name,
+            'column': 0,
+        },
+    }
+    read_X_Y_from_combined(curve_info)
+    assert curve_info['X_values'] == [10.0, 20.0, 30.0]
+    assert curve_info['Y_values'] == [1.0, 2.0, 3.0]


### PR DESCRIPTION
## Summary
- allow selecting X or Y column for text and LS-DYNA files in combined curves
- default column saved for textual sources to honor user choice
- test column selection for text and LS-DYNA inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689991ebfa04832aa1c1dc9dd7ce2701