### PR TITLE
Обновление хранения данных последнего графика

### DIFF
--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -227,12 +227,13 @@ def generate_graph(ax, fig, canvas, path_entry_title, combo_titleX, combo_titleX
 
     # Сохраняем данные графика для последующего сохранения в файл
     global last_graph
-    last_graph = {
+    last_graph.clear()
+    last_graph.update({
         'curves_info': curves_info,
         'X_label': xlabel,
         'Y_label': ylabel,
         'title': title,
-    }
+    })
 
     # Перерисовка графика
     canvas.draw()

--- a/tests/test_last_graph_save_file.py
+++ b/tests/test_last_graph_save_file.py
@@ -1,0 +1,32 @@
+import matplotlib
+matplotlib.use('Agg')
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tabs.functions_for_tab1 import plotting
+from tabs import tab1
+
+
+def test_save_file_uses_updated_last_graph(tmp_path):
+    # убеждаемся, что last_graph используется как общий объект
+    assert tab1.last_graph is plotting.last_graph
+
+    # имитируем обновление графика
+    plotting.last_graph.clear()
+    plotting.last_graph.update({
+        'curves_info': [{'X_values': [0, 1], 'Y_values': [0, 1]}],
+        'X_label': 'X',
+        'Y_label': 'Y',
+        'title': 'T',
+    })
+
+    entry = SimpleNamespace(get=lambda: 'graph')
+    file_path = tmp_path / 'out.png'
+
+    with patch('tabs.functions_for_tab1.plotting.filedialog.asksaveasfilename', return_value=str(file_path)), \
+         patch('tabs.functions_for_tab1.plotting.messagebox.showinfo'), \
+         patch('tabs.functions_for_tab1.plotting.messagebox.showerror'):
+        tab1.save_file(entry, tab1.last_graph)
+
+    assert file_path.exists()


### PR DESCRIPTION
## Summary
- Обновлён `generate_graph` для очистки и обновления `last_graph` вместо создания нового словаря
- Добавлен тест, подтверждающий сохранение графика через `save_file` с актуальным `last_graph`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a14ac7fac832aa1fc3c5bbd11dd62