### PR TITLE
Исправление подписи осей при выборе «Другое»

### DIFF
--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -14,9 +14,10 @@ last_graph = {}
 
 
 class AxisTitleProcessor:
-    def __init__(self, combo_title, combo_size, language='Русский'):
+    def __init__(self, combo_title, combo_size, entry_title=None, language='Русский'):
         self.combo_title = combo_title
         self.combo_size = combo_size
+        self.entry_title = entry_title
         self.language = language
         self.title_mapping = {
             "Время": {
@@ -80,8 +81,8 @@ class AxisTitleProcessor:
         return self.title_mapping.get(selection, {}).get(self.language, selection)
 
     def get_processed_title(self):
-        if self.combo_title.get() == "Другое" and self.combo_size.get():
-            return f"{self.combo_size.get()}"
+        if self.combo_title.get() == "Другое":
+            return self.entry_title.get() if self.entry_title else ""
         title = self._get_title()
         return f"{title}{self._get_units()}"
 
@@ -126,16 +127,16 @@ def get_X_Y_data(curve_info):
         read_X_Y_from_combined(curve_info)
 
 
-def generate_graph(ax, fig, canvas, path_entry_title, combo_titleX, combo_titleX_size, combo_titleY, combo_titleY_size,
-                   legend_checkbox, curves_frame, combo_curves, combo_language):
+def generate_graph(ax, fig, canvas, path_entry_title, combo_titleX, combo_titleX_size, entry_titleX,
+                   combo_titleY, combo_titleY_size, entry_titleY, legend_checkbox, curves_frame, combo_curves, combo_language):
 
     # Очистка предыдущего графика
     ax.clear()
     # Считываем заголовок из поля ввода
     title = path_entry_title.get()
     language = combo_language.get() or 'Русский'
-    xlabel_processor = AxisTitleProcessor(combo_titleX, combo_titleX_size, language)
-    ylabel_processor = AxisTitleProcessor(combo_titleY, combo_titleY_size, language)
+    xlabel_processor = AxisTitleProcessor(combo_titleX, combo_titleX_size, entry_titleX, language)
+    ylabel_processor = AxisTitleProcessor(combo_titleY, combo_titleY_size, entry_titleY, language)
     xlabel = xlabel_processor.get_processed_title()
     ylabel = ylabel_processor.get_processed_title()
 

--- a/tabs/tab1.py
+++ b/tabs/tab1.py
@@ -173,8 +173,8 @@ def create_tab1(notebook):
         text="Построить график",
         command=lambda: generate_graph(
             ax, fig, canvas, path_entry_title,
-            combo_titleX, combo_titleX_size,
-            combo_titleY, combo_titleY_size,
+            combo_titleX, combo_titleX_size, path_entry_titleX,
+            combo_titleY, combo_titleY_size, path_entry_titleY,
             checkbox_var, curves_frame, combo_curves, combo_language
         )
     )


### PR DESCRIPTION
## Summary
- Использован текст из поля ввода при выборе варианта «Другое» для подписей осей
- Переданы виджеты текстовых полей в генератор графика

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a1d107e08832a8363ddf77526164d