### PR TITLE
Добавить выбор формата при сохранении графика

### DIFF
--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -90,24 +90,29 @@ class AxisTitleProcessor:
         return f"{title}{self._get_units()}"
 
 
-def save_file(entry_widget, graph_info):
+def save_file(entry_widget, format_widget, graph_info):
 
     file_name = entry_widget.get()
-    if file_name:
-        file_path = filedialog.asksaveasfilename(defaultextension=".png",
-                                                 filetypes=[("PNG files", "*.png"), ("All files", "*.*")],
-                                                 initialfile=file_name)
+    file_format = format_widget.get()
+    if file_name and file_format:
+        file_path = filedialog.asksaveasfilename(
+            defaultextension=f".{file_format}",
+            filetypes=[(f"{file_format.upper()} files", f"*.{file_format}"), ("All files", "*.*")],
+            initialfile=f"{file_name}.{file_format}",
+        )
         if file_path:
             try:
                 fig = graph_info.get('fig')
                 if fig is None:
                     raise ValueError("Нет фигуры для сохранения")
-                fig.savefig(file_path)
+                fig.savefig(file_path, format=file_format)
                 messagebox.showinfo("Успех", f"График сохранен: {file_path}")
             except Exception as e:
                 messagebox.showerror("Ошибка", f"Не удалось сохранить файл: {str(e)}")
-    else:
+    elif not file_name:
         messagebox.showerror("Ошибка", "Имя файла не может быть пустым!")
+    else:
+        messagebox.showerror("Ошибка", "Не выбран формат файла!")
 
 
 def get_X_Y_data(curve_info):

--- a/tabs/tab1.py
+++ b/tabs/tab1.py
@@ -207,12 +207,17 @@ def create_tab1(notebook):
         save_frame, method="entry", height=1, state='normal', scrollbar=False
     )
     entry_save.place(x=10, y=30, width=300)
+    label_format = ttk.Label(save_frame, text="Формат:")
+    label_format.place(x=330, y=0)
+    combo_format = ttk.Combobox(save_frame, values=["png", "jpg", "svg", "pdf"], state='readonly')
+    combo_format.place(x=330, y=30, width=80)
+    combo_format.current(0)
     save_button = ttk.Button(
         save_frame,
         text="Сохранить",
-        command=lambda: save_file(entry_save, last_graph)
+        command=lambda: save_file(entry_save, combo_format, last_graph)
     )
-    save_button.place(x=330, y=30)
+    save_button.place(x=420, y=30)
 
     # Чекбокс легенды
     checkbox = ttk.Checkbutton(

--- a/tests/test_last_graph_save_file.py
+++ b/tests/test_last_graph_save_file.py
@@ -27,11 +27,12 @@ def test_save_file_uses_updated_last_graph(tmp_path):
     })
 
     entry = SimpleNamespace(get=lambda: 'graph')
+    fmt_widget = SimpleNamespace(get=lambda: 'png')
     file_path = tmp_path / 'out.png'
 
     with patch('tabs.functions_for_tab1.plotting.filedialog.asksaveasfilename', return_value=str(file_path)), \
          patch('tabs.functions_for_tab1.plotting.messagebox.showinfo'), \
          patch('tabs.functions_for_tab1.plotting.messagebox.showerror'):
-        tab1.save_file(entry, tab1.last_graph)
+        tab1.save_file(entry, fmt_widget, tab1.last_graph)
 
     assert file_path.exists()


### PR DESCRIPTION
## Summary
- Добавлено выпадающее меню для выбора формата сохранения графика
- Обновлена логика сохранения, учитывающая выбранный формат
- Исправлены тесты с учётом нового параметра

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a37983d8c832aa7a633436b9e179b