### PR TITLE
Добавление окон ошибок при проблемах чтения файлов

### DIFF
--- a/tabs/functions_for_tab1/curves_from_file/combined_curve.py
+++ b/tabs/functions_for_tab1/curves_from_file/combined_curve.py
@@ -43,43 +43,53 @@ def _read_axis(axis_info, column=0):
     column = _column_to_index(column, 0)
     source_type = axis_info.get("source")
     tmp_info = {"curve_file": axis_info.get("curve_file", "")}
+    path = tmp_info["curve_file"]
+    try:
+        if source_type == "Частотный анализ":
+            tmp_info.update({
+                "curve_typeXF": axis_info.get("parameter", ""),
+                "curve_typeYF": axis_info.get("parameter", ""),
+                "curve_typeXF_type": axis_info.get("direction", ""),
+                "curve_typeYF_type": axis_info.get("direction", ""),
+            })
+            read_X_Y_from_frequency_analysis(tmp_info)
+            return tmp_info.get("X_values", []) if column == 0 else tmp_info.get("Y_values", [])
 
-    if source_type == "Частотный анализ":
-        tmp_info.update({
-            "curve_typeXF": axis_info.get("parameter", ""),
-            "curve_typeYF": axis_info.get("parameter", ""),
-            "curve_typeXF_type": axis_info.get("direction", ""),
-            "curve_typeYF_type": axis_info.get("direction", ""),
-        })
-        read_X_Y_from_frequency_analysis(tmp_info)
-        return tmp_info.get("X_values", []) if column == 0 else tmp_info.get("Y_values", [])
+        if source_type == "Текстовой файл":
+            read_X_Y_from_text_file(tmp_info)
+            return tmp_info.get("X_values", []) if column == 0 else tmp_info.get("Y_values", [])
 
-    if source_type == "Текстовой файл":
-        read_X_Y_from_text_file(tmp_info)
-        return tmp_info.get("X_values", []) if column == 0 else tmp_info.get("Y_values", [])
+        if source_type == "Файл кривой LS-Dyna":
+            read_X_Y_from_ls_dyna(tmp_info)
+            return tmp_info.get("X_values", []) if column == 0 else tmp_info.get("Y_values", [])
 
-    if source_type == "Файл кривой LS-Dyna":
-        read_X_Y_from_ls_dyna(tmp_info)
-        return tmp_info.get("X_values", []) if column == 0 else tmp_info.get("Y_values", [])
+        if source_type == "Excel файл":
+            tmp_info.update({
+                "horizontal": axis_info.get("horizontal", False),
+                "use_offset": axis_info.get("use_offset", False),
+                "offset_horizontal": axis_info.get("offset_horizontal", 0),
+                "offset_vertical": axis_info.get("offset_vertical", 0),
+                "use_ranges": axis_info.get("use_ranges", False),
+            })
+            if column == 0:
+                tmp_info["range_x"] = axis_info.get("range_x", "")
+                tmp_info["range_y"] = ""
+            else:
+                tmp_info["range_x"] = ""
+                tmp_info["range_y"] = axis_info.get("range_y", "")
+            read_X_Y_from_excel(tmp_info)
+            return tmp_info.get("X_values", []) if column == 0 else tmp_info.get("Y_values", [])
 
-    if source_type == "Excel файл":
-        tmp_info.update({
-            "horizontal": axis_info.get("horizontal", False),
-            "use_offset": axis_info.get("use_offset", False),
-            "offset_horizontal": axis_info.get("offset_horizontal", 0),
-            "offset_vertical": axis_info.get("offset_vertical", 0),
-            "use_ranges": axis_info.get("use_ranges", False),
-        })
-        if column == 0:
-            tmp_info["range_x"] = axis_info.get("range_x", "")
-            tmp_info["range_y"] = ""
-        else:
-            tmp_info["range_x"] = ""
-            tmp_info["range_y"] = axis_info.get("range_y", "")
-        read_X_Y_from_excel(tmp_info)
-        return tmp_info.get("X_values", []) if column == 0 else tmp_info.get("Y_values", [])
-
-    logger.error("Неизвестный источник данных: %s", source_type)
+        logger.error("Неизвестный источник данных: %s", source_type)
+        return []
+    except FileNotFoundError:
+        logger.error("Файл '%s' не найден.", path)
+        from tkinter import messagebox
+        messagebox.showerror("Ошибка", f"Не удалось открыть файл {path}")
+    except Exception:
+        logger.error("Ошибка при чтении файла '%s'.", path)
+        from tkinter import messagebox
+        messagebox.showerror("Ошибка", f"Не удалось открыть файл {path}")
     return []
 
 

--- a/tabs/functions_for_tab1/curves_from_file/excel_file.py
+++ b/tabs/functions_for_tab1/curves_from_file/excel_file.py
@@ -168,5 +168,9 @@ def read_X_Y_from_excel(curve_info):
         curve_info['Y_values'] = Y_data
     except FileNotFoundError:
         logger.error("Файл '%s' не найден.", curve_info['curve_file'])
+        from tkinter import messagebox
+        messagebox.showerror("Ошибка", f"Не удалось открыть файл {path}")
     except Exception:
         logger.error("Ошибка при чтении файла '%s'.", curve_info['curve_file'])
+        from tkinter import messagebox
+        messagebox.showerror("Ошибка", f"Не удалось открыть файл {path}")

--- a/tabs/functions_for_tab1/curves_from_file/frequency_analysis.py
+++ b/tabs/functions_for_tab1/curves_from_file/frequency_analysis.py
@@ -6,7 +6,8 @@ logger = logging.getLogger(__name__)
 
 def read_X_Y_from_frequency_analysis(curve_info):
     try:
-        with open(curve_info['curve_file'], 'r') as file:
+        path = curve_info['curve_file']
+        with open(path, 'r') as file:
             lines = file.readlines()
 
         header_XF = (
@@ -89,5 +90,9 @@ def read_X_Y_from_frequency_analysis(curve_info):
 
     except FileNotFoundError:
         logger.error("Файл '%s' не найден.", curve_info['curve_file'])
-    except IOError:
+        from tkinter import messagebox
+        messagebox.showerror("Ошибка", f"Не удалось открыть файл {path}")
+    except Exception:
         logger.error("Ошибка при чтении файла '%s'.", curve_info['curve_file'])
+        from tkinter import messagebox
+        messagebox.showerror("Ошибка", f"Не удалось открыть файл {path}")

--- a/tabs/functions_for_tab1/curves_from_file/ls_dyna_file.py
+++ b/tabs/functions_for_tab1/curves_from_file/ls_dyna_file.py
@@ -5,9 +5,10 @@ logger = logging.getLogger(__name__)
 
 def read_X_Y_from_ls_dyna(curve_info):
     try:
+        path = curve_info['curve_file']
         X_data = []
         Y_data = []
-        with open(curve_info['curve_file'], 'r', encoding='utf-8') as file:
+        with open(path, 'r', encoding='utf-8') as file:
             for line in file:
                 line = line.strip()
                 if not line:
@@ -26,5 +27,9 @@ def read_X_Y_from_ls_dyna(curve_info):
         curve_info['Y_values'] = Y_data
     except FileNotFoundError:
         logger.error("Файл '%s' не найден.", curve_info['curve_file'])
-    except IOError:
+        from tkinter import messagebox
+        messagebox.showerror("Ошибка", f"Не удалось открыть файл {path}")
+    except Exception:
         logger.error("Ошибка при чтении файла '%s'.", curve_info['curve_file'])
+        from tkinter import messagebox
+        messagebox.showerror("Ошибка", f"Не удалось открыть файл {path}")

--- a/tabs/functions_for_tab1/curves_from_file/text_file.py
+++ b/tabs/functions_for_tab1/curves_from_file/text_file.py
@@ -5,9 +5,10 @@ logger = logging.getLogger(__name__)
 
 def read_X_Y_from_text_file(curve_info):
     try:
+        path = curve_info['curve_file']
         X_data = []
         Y_data = []
-        with open(curve_info['curve_file'], 'r', encoding='utf-8') as file:
+        with open(path, 'r', encoding='utf-8') as file:
             for line in file:
                 line = line.strip()
                 if not line:
@@ -24,5 +25,9 @@ def read_X_Y_from_text_file(curve_info):
         curve_info['Y_values'] = Y_data
     except FileNotFoundError:
         logger.error("Файл '%s' не найден.", curve_info['curve_file'])
-    except IOError:
+        from tkinter import messagebox
+        messagebox.showerror("Ошибка", f"Не удалось открыть файл {path}")
+    except Exception:
         logger.error("Ошибка при чтении файла '%s'.", curve_info['curve_file'])
+        from tkinter import messagebox
+        messagebox.showerror("Ошибка", f"Не удалось открыть файл {path}")


### PR DESCRIPTION
## Summary
- Показывать окно `messagebox` при ошибках открытия файлов в функциях чтения
- Обрабатывать `FileNotFoundError` и другие ошибки чтения во всех источниках данных

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a48aeb368832ab3649ec0a417acd3