### PR TITLE
Предупреждение при сохранении без графика

### DIFF
--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -92,6 +92,11 @@ class AxisTitleProcessor:
 
 def save_file(entry_widget, format_widget, graph_info):
 
+    fig = graph_info.get('fig')
+    if fig is None:
+        messagebox.showwarning("Предупреждение", "Сначала постройте график")
+        return
+
     file_name = entry_widget.get()
     file_format = format_widget.get()
     if file_name and file_format:
@@ -102,9 +107,6 @@ def save_file(entry_widget, format_widget, graph_info):
         )
         if file_path:
             try:
-                fig = graph_info.get('fig')
-                if fig is None:
-                    raise ValueError("Нет фигуры для сохранения")
                 fig.savefig(file_path, format=file_format)
                 messagebox.showinfo("Успех", f"График сохранен: {file_path}")
             except Exception as e:

--- a/tests/test_save_file_no_graph.py
+++ b/tests/test_save_file_no_graph.py
@@ -1,0 +1,17 @@
+import matplotlib
+matplotlib.use('Agg')
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tabs.functions_for_tab1 import plotting
+
+
+def test_save_file_warns_without_graph():
+    entry = SimpleNamespace(get=lambda: 'graph')
+    fmt_widget = SimpleNamespace(get=lambda: 'png')
+    graph_info = {}
+    with patch('tabs.functions_for_tab1.plotting.filedialog.asksaveasfilename') as ask, \
+         patch('tabs.functions_for_tab1.plotting.messagebox.showwarning') as warn:
+        plotting.save_file(entry, fmt_widget, graph_info)
+        warn.assert_called_once_with("Предупреждение", "Сначала постройте график")
+        ask.assert_not_called()


### PR DESCRIPTION
## Summary
- Предотвращено сохранение файла без построенного графика
- Добавлен тест на предупреждение при отсутствии графика

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a508b70e0832a99149b505ab10c43