### PR TITLE
Пропуск заголовков в LS-Dyna файлах

### DIFF
--- a/tabs/functions_for_tab1/curves_from_file/ls_dyna_file.py
+++ b/tabs/functions_for_tab1/curves_from_file/ls_dyna_file.py
@@ -5,29 +5,35 @@ logger = logging.getLogger(__name__)
 
 
 def read_X_Y_from_ls_dyna(curve_info):
+    """Читает значения X и Y из файла LS-Dyna.
+
+    Строки, не содержащие хотя бы двух числовых значений (заголовки,
+    комментарии и т.п.), пропускаются без генерации сообщения об ошибке.
+    """
     try:
         path = curve_info['curve_file']
-        X_data = []
-        Y_data = []
+        X_data: list[float] = []
+        Y_data: list[float] = []
         with open(path, 'r', encoding='utf-8') as file:
-            for line in file:
-                line = line.strip()
+            for raw_line in file:
+                line = raw_line.strip()
                 if not line:
                     continue
+                if line.startswith('*') or line.startswith('#'):
+                    continue
+                if '#' in line:
+                    line = line.split('#', 1)[0].strip()
                 parts = line.split()
-                if len(parts) < 2:
-                    logger.error("Некорректная строка данных: %s", line)
-                    messagebox.showerror("Ошибка", f"Некорректные данные в строке: {line}")
-                    return
-                try:
-                    x = float(parts[0])
-                    y = float(parts[1])
-                except ValueError:
-                    logger.error("Некорректная строка данных: %s", line)
-                    messagebox.showerror("Ошибка", f"Некорректные данные в строке: {line}")
-                    return
-                X_data.append(x)
-                Y_data.append(y)
+                numbers = []
+                for part in parts:
+                    try:
+                        numbers.append(float(part))
+                    except ValueError:
+                        continue
+                if len(numbers) < 2:
+                    continue
+                X_data.append(numbers[0])
+                Y_data.append(numbers[1])
         curve_info['X_values'] = X_data
         curve_info['Y_values'] = Y_data
     except FileNotFoundError:

--- a/tests/test_ls_dyna_file_with_header.py
+++ b/tests/test_ls_dyna_file_with_header.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from tabs.functions_for_tab1.curves_from_file.ls_dyna_file import read_X_Y_from_ls_dyna
+
+
+def test_ls_dyna_example_with_header():
+    file_path = Path(__file__).resolve().parents[1] / 'examples' / 'LsDynaText' / 'LsDyna_example.txt'
+    curve_info = {'curve_file': str(file_path)}
+    read_X_Y_from_ls_dyna(curve_info)
+    assert curve_info['X_values'][:3] == [0.0, 9.9993146956e-02, 1.9999520481e-01]
+    assert curve_info['Y_values'][:3] == [0.0, 7.6113149524e-02, 8.0158777535e-02]


### PR DESCRIPTION
## Summary
- Игнорирование строк без двух числовых значений при чтении LS-Dyna
- Добавлен юнит-тест для файла `LsDyna_example.txt`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ba5a8c634832aa53e209468c9890d