### PR TITLE
Проверка расширения для текстовых файлов

### DIFF
--- a/tabs/functions_for_tab1/curves_from_file/text_file.py
+++ b/tabs/functions_for_tab1/curves_from_file/text_file.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from tkinter import messagebox
 
 logger = logging.getLogger(__name__)
@@ -6,7 +7,13 @@ logger = logging.getLogger(__name__)
 
 def read_X_Y_from_text_file(curve_info):
     try:
-        path = curve_info['curve_file']
+        path = Path(curve_info['curve_file'])
+        suffix = path.suffix.lower()
+        if suffix and suffix != '.txt':
+            logger.error("Неподдерживаемый формат файла: %s", suffix)
+            messagebox.showerror("Ошибка", f"Ожидался файл с расширением .txt, получен {suffix}")
+            return
+
         X_data = []
         Y_data = []
         with open(path, 'r', encoding='utf-8') as file:

--- a/tests/test_text_file_invalid_extension.py
+++ b/tests/test_text_file_invalid_extension.py
@@ -1,0 +1,19 @@
+import tempfile
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from tabs.functions_for_tab1.curves_from_file.text_file import read_X_Y_from_text_file
+
+
+def test_text_file_invalid_extension():
+    with tempfile.NamedTemporaryFile('w', suffix='.csv', delete=False) as tmp:
+        tmp.write('1,2\n3,4\n')
+        tmp_path = tmp.name
+
+    curve_info = {'curve_file': tmp_path}
+    with patch('tabs.functions_for_tab1.curves_from_file.text_file.messagebox.showerror'):
+        read_X_Y_from_text_file(curve_info)
+    assert 'X_values' not in curve_info
+    assert 'Y_values' not in curve_info


### PR DESCRIPTION
## Summary
- добавлена проверка расширения для чтения текстовых кривых
- добавлен тест, запрещающий чтение .csv как .txt

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bae15d624832a99d83887659a13d7