### PR TITLE
feat: add shared TXT reader adapter

### DIFF
--- a/tabs/function_for_all_tabs/__init__.py
+++ b/tabs/function_for_all_tabs/__init__.py
@@ -1,3 +1,4 @@
 from .plotting import create_plot
+from .parsing_utils import read_pairs
 
-__all__ = ["create_plot"]
+__all__ = ["create_plot", "read_pairs"]

--- a/tabs/function_for_all_tabs/parsing_utils.py
+++ b/tabs/function_for_all_tabs/parsing_utils.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from typing import List, Tuple
+
+from tabs.functions_for_tab1.curves_from_file.text_file import read_X_Y_from_text_file
+
+
+def read_pairs(path: str) -> Tuple[List[float], List[float]]:
+    """Read X and Y value pairs from a text file.
+
+    This function is a thin adapter over
+    :func:`tabs.functions_for_tab1.curves_from_file.text_file.read_X_Y_from_text_file`.
+    It delegates parsing to the existing implementation and simply returns the
+    extracted arrays of X and Y values.
+    """
+    path_obj = Path(path)
+    if not path_obj.exists():
+        raise FileNotFoundError(path)
+
+    curve_info = {"curve_file": str(path_obj)}
+    read_X_Y_from_text_file(curve_info)
+    try:
+        return curve_info["X_values"], curve_info["Y_values"]
+    except KeyError as exc:
+        raise ValueError("Некорректные данные в файле") from exc

--- a/tests/test_parsing_utils_read_pairs.py
+++ b/tests/test_parsing_utils_read_pairs.py
@@ -1,0 +1,37 @@
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from tabs.function_for_all_tabs.parsing_utils import read_pairs
+
+
+def test_read_pairs_valid_file():
+    with tempfile.NamedTemporaryFile('w', suffix='.txt', delete=False) as tmp:
+        tmp.write('1 2\n3,4\n\n5 6\n')
+        path = tmp.name
+
+    x, y = read_pairs(path)
+    assert x == [1.0, 3.0, 5.0]
+    assert y == [2.0, 4.0, 6.0]
+    Path(path).unlink()
+
+
+def test_read_pairs_invalid_line():
+    with tempfile.NamedTemporaryFile('w', suffix='.txt', delete=False) as tmp:
+        tmp.write('1 2\ninvalid\n')
+        path = tmp.name
+
+    with patch('tabs.functions_for_tab1.curves_from_file.text_file.messagebox.showerror'), \
+            pytest.raises(ValueError):
+        read_pairs(path)
+    Path(path).unlink()
+
+
+def test_read_pairs_missing_file():
+    missing = Path('nonexistent_file.txt')
+    with pytest.raises(FileNotFoundError):
+        read_pairs(missing)


### PR DESCRIPTION
## Summary
- add `read_pairs` adapter to reuse existing TXT parsing logic
- expose new adapter in `function_for_all_tabs`
- test valid, invalid and missing TXT files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a369bdd870832a90971ac84e1e5f15