### PR TITLE
Реализовано вычисление зависимой координаты для таба 2

### DIFF
--- a/functions_for_tab2/dependent.py
+++ b/functions_for_tab2/dependent.py
@@ -1,0 +1,110 @@
+"""Utilities for computing dependent coordinate values for tab2.
+
+This module provides :func:`compute_dependent_values` which transforms the
+user configuration of the dependent coordinate into numeric arrays.  Several
+modes are supported:
+
+``const``
+    Return an array filled with a constant.
+``array``
+    Parse explicit array values from text.
+``expr``
+    Evaluate a mathematical expression using :func:`safe_eval_expr`.
+``from_file``
+    Load X/Y value pairs from a file using the same readers as tab1.
+``manual_pairs``
+    Parse X/Y pairs directly from a text block.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal, Optional, Tuple
+
+import numpy as np
+
+from function_for_all_tabs.safe_eval import safe_eval_expr
+from tabs.function_for_all_tabs.parsing_utils import parse_numbers
+from tabs.functions_for_tab1.curves_from_file import (
+    read_X_Y_from_excel,
+    read_X_Y_from_ls_dyna,
+    read_X_Y_from_text_file,
+)
+
+Array = np.ndarray
+
+
+def _parse_manual_pairs(text: str) -> Tuple[Array, Array]:
+    """Parse ``(x, y)`` pairs from a multiline string."""
+
+    xs: list[float] = []
+    ys: list[float] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        numbers = parse_numbers(line)
+        if numbers.size < 2:
+            raise ValueError(f"Некорректные данные в строке: {line}")
+        xs.append(float(numbers[0]))
+        ys.append(float(numbers[1]))
+    return np.asarray(xs, dtype=float), np.asarray(ys, dtype=float)
+
+
+def _read_pairs_from_file(path: str) -> Tuple[Array, Array]:
+    """Read X and Y arrays from ``path`` using tab1 readers."""
+
+    curve_info = {"curve_file": path}
+    suffix = Path(path).suffix.lower()
+    if suffix in {".xlsx", ".xlsm", ".csv"}:
+        read_X_Y_from_excel(curve_info)
+    else:
+        # LS-DYNA files often have ``.txt`` extension.  Try the specialised
+        # reader first and fall back to a plain text reader on error.
+        try:
+            read_X_Y_from_ls_dyna(curve_info)
+        except Exception:
+            read_X_Y_from_text_file(curve_info)
+    return (
+        np.asarray(curve_info.get("X_values", []), dtype=float),
+        np.asarray(curve_info.get("Y_values", []), dtype=float),
+    )
+
+
+def compute_dependent_values(
+    dep_mode: str,
+    grid: Array,
+    *,
+    arg_name: Literal["x", "y"],
+    const_value: float,
+    array_values_text: str,
+    expr_text: str,
+    dep_file_path: str,
+    manual_pairs_text: str,
+) -> Tuple[Optional[Array], Optional[Array]]:
+    """Compute dependent coordinate values according to ``dep_mode``."""
+
+    if dep_mode == "const":
+        values = np.full_like(grid, const_value, dtype=float)
+        return None, values
+
+    if dep_mode == "array":
+        values = parse_numbers(array_values_text)
+        if values.size != grid.size:
+            raise ValueError("Длины массива и сетки не совпадают")
+        return None, values
+
+    if dep_mode == "expr":
+        values = safe_eval_expr(expr_text, **{arg_name: grid})
+        return None, np.asarray(values, dtype=float)
+
+    if dep_mode == "from_file":
+        return _read_pairs_from_file(dep_file_path)
+
+    if dep_mode == "manual_pairs":
+        return _parse_manual_pairs(manual_pairs_text)
+
+    raise ValueError(f"Неизвестный режим: {dep_mode}")
+
+
+__all__ = ["compute_dependent_values"]

--- a/tests/test_dependent_values.py
+++ b/tests/test_dependent_values.py
@@ -1,0 +1,68 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from functions_for_tab2.dependent import compute_dependent_values
+
+
+def test_const_mode():
+    grid = np.array([0.0, 1.0, 2.0])
+    x, vals = compute_dependent_values(
+        "const", grid, arg_name="x", const_value=2.5,
+        array_values_text="", expr_text="", dep_file_path="", manual_pairs_text=""
+    )
+    assert x is None
+    assert np.allclose(vals, [2.5, 2.5, 2.5])
+
+
+def test_array_mode():
+    grid = np.array([0.0, 1.0, 2.0])
+    x, vals = compute_dependent_values(
+        "array", grid, arg_name="x", const_value=0.0,
+        array_values_text="1, 2, 3", expr_text="", dep_file_path="", manual_pairs_text=""
+    )
+    assert x is None
+    assert np.allclose(vals, [1.0, 2.0, 3.0])
+
+    with pytest.raises(ValueError):
+        compute_dependent_values(
+            "array", grid, arg_name="x", const_value=0.0,
+            array_values_text="1, 2", expr_text="", dep_file_path="", manual_pairs_text=""
+        )
+
+
+def test_expr_mode():
+    grid = np.array([0.0, 1.0, 2.0])
+    x, vals = compute_dependent_values(
+        "expr", grid, arg_name="x", const_value=0.0,
+        array_values_text="", expr_text="x*2", dep_file_path="", manual_pairs_text=""
+    )
+    assert x is None
+    assert np.allclose(vals, [0.0, 2.0, 4.0])
+
+
+def test_from_file_uses_tab1_reader(tmp_path):
+    grid = np.array([0.0])
+    dummy_path = tmp_path / "data.txt"
+
+    def fake_ls_dyna(info):
+        raise ValueError
+
+    def fake_text(info):
+        info["X_values"] = [1.0, 2.0]
+        info["Y_values"] = [3.0, 4.0]
+
+    with patch("functions_for_tab2.dependent.read_X_Y_from_ls_dyna", side_effect=fake_ls_dyna), \
+         patch("functions_for_tab2.dependent.read_X_Y_from_text_file", side_effect=fake_text) as mock_text:
+        X, Y = compute_dependent_values(
+            "from_file", grid, arg_name="x", const_value=0.0,
+            array_values_text="", expr_text="", dep_file_path=str(dummy_path), manual_pairs_text=""
+        )
+    assert mock_text.called
+    assert np.allclose(X, [1.0, 2.0])
+    assert np.allclose(Y, [3.0, 4.0])


### PR DESCRIPTION
## Summary
- добавлена функция вычисления зависимой координаты с поддержкой режимов константы, массива, выражения, чтения из файла и ручных пар
- реализован разбор пар и адаптер чтения файлов через механизмы таба 1
- покрыт модуль тестами на основные режимы и интеграцией чтения из файла

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a36dc35e64832aba806237facdef28