### PR TITLE
feat: add segment stitching utility

### DIFF
--- a/functions_for_tab2/__init__.py
+++ b/functions_for_tab2/__init__.py
@@ -4,5 +4,6 @@ This package exposes data models used by the tab implementation.
 """
 
 from .models import ComputedSegment, IntervalSpec
+from .stitch import stitch_segments
 
-__all__ = ["IntervalSpec", "ComputedSegment"]
+__all__ = ["IntervalSpec", "ComputedSegment", "stitch_segments"]

--- a/functions_for_tab2/stitch.py
+++ b/functions_for_tab2/stitch.py
@@ -1,0 +1,89 @@
+"""Utilities for stitching computed segments.
+
+This module provides functionality to merge multiple
+:class:`~functions_for_tab2.models.ComputedSegment` instances into a
+continuous curve.  Optionally, segments can be adjusted to ensure
+continuity of the argument axis.
+"""
+
+from __future__ import annotations
+
+from typing import List, Literal
+
+import numpy as np
+
+from .models import ComputedSegment
+
+
+Array = np.ndarray
+
+
+def stitch_segments(
+    segments: List[ComputedSegment],
+    primary_sequence: List[Literal["X", "Y"]],
+    require_continuity: bool,
+    tol: float = 1e-8,
+) -> ComputedSegment:
+    """Concatenate segments into a single curve.
+
+    Parameters
+    ----------
+    segments:
+        List of segments to be concatenated.
+    primary_sequence:
+        Sequence indicating which axis acts as the independent variable for
+        each segment.  Must be the same length as ``segments``.
+    require_continuity:
+        When ``True``, the first point of each subsequent segment is adjusted
+        to match the last point of the previous segment along its argument
+        axis if the values differ by less than ``tol``.
+    tol:
+        Tolerance for comparing axis values.
+
+    Returns
+    -------
+    ComputedSegment
+        New segment containing the concatenated ``X`` and ``Y`` arrays.
+    """
+
+    if not segments:
+        return ComputedSegment(X=np.array([], dtype=float), Y=np.array([], dtype=float))
+
+    if len(segments) != len(primary_sequence):
+        raise ValueError("Длина primary_sequence должна совпадать с количеством сегментов")
+
+    xs = [segments[0].X.copy()]
+    ys = [segments[0].Y.copy()]
+
+    last_x = xs[0][-1]
+    last_y = ys[0][-1]
+
+    for seg, primary in zip(segments[1:], primary_sequence[1:]):
+        X = seg.X.copy()
+        Y = seg.Y.copy()
+
+        if require_continuity:
+            if primary == "X" and abs(X[0] - last_x) <= tol:
+                X[0] = last_x
+            elif primary == "Y" and abs(Y[0] - last_y) <= tol:
+                Y[0] = last_y
+
+        is_duplicate = abs(X[0] - last_x) <= tol and abs(Y[0] - last_y) <= tol
+        if not require_continuity:
+            eps = np.finfo(float).eps
+            is_duplicate = abs(X[0] - last_x) <= eps and abs(Y[0] - last_y) <= eps
+
+        if is_duplicate:
+            xs.append(X[1:])
+            ys.append(Y[1:])
+        else:
+            xs.append(X)
+            ys.append(Y)
+
+        last_x = X[-1]
+        last_y = Y[-1]
+
+    return ComputedSegment(X=np.concatenate(xs), Y=np.concatenate(ys))
+
+
+__all__ = ["stitch_segments"]

--- a/tests/test_stitch_segments.py
+++ b/tests/test_stitch_segments.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from functions_for_tab2.models import ComputedSegment
+from functions_for_tab2.stitch import stitch_segments
+
+
+def test_stitch_with_continuity_adjustment():
+    seg1 = ComputedSegment(
+        X=np.array([0.0, 1.0, 2.0]),
+        Y=np.array([0.0, 1.0, 4.0]),
+    )
+    seg2 = ComputedSegment(
+        X=np.array([2.0 + 1e-9, 3.0, 4.0]),
+        Y=np.array([4.0, 9.0, 16.0]),
+    )
+
+    stitched = stitch_segments([seg1, seg2], ["X", "X"], True, tol=1e-8)
+
+    assert np.allclose(stitched.X, [0.0, 1.0, 2.0, 3.0, 4.0])
+    assert np.allclose(stitched.Y, [0.0, 1.0, 4.0, 9.0, 16.0])
+
+
+def test_stitch_without_continuity():
+    seg1 = ComputedSegment(
+        X=np.array([0.0, 1.0, 2.0]),
+        Y=np.array([0.0, 1.0, 4.0]),
+    )
+    seg2 = ComputedSegment(
+        X=np.array([2.0 + 1e-9, 3.0, 4.0]),
+        Y=np.array([4.0, 9.0, 16.0]),
+    )
+
+    stitched = stitch_segments([seg1, seg2], ["X", "X"], False, tol=1e-8)
+
+    assert np.allclose(stitched.X, [0.0, 1.0, 2.0, 2.0 + 1e-9, 3.0, 4.0])
+    assert np.allclose(stitched.Y, [0.0, 1.0, 4.0, 4.0, 9.0, 16.0])


### PR DESCRIPTION
## Summary
- add utility to stitch multiple computed segments with optional continuity adjustments
- expose new stitch_segments helper via package init
- cover segment stitching logic with unit tests

## Testing
- `pytest tests/test_stitch_segments.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a370cd2abc832a88f0ccae0052ef31