### PR TITLE
Добавить экспорт кривой в текстовый файл

### DIFF
--- a/functions_for_tab2/exporting.py
+++ b/functions_for_tab2/exporting.py
@@ -1,0 +1,42 @@
+"""Utilities for exporting computed curves to text files."""
+
+from __future__ import annotations
+
+import numpy as np
+
+Array = np.ndarray
+
+
+def export_curve_txt(path: str, X: Array, Y: Array, precision: int) -> None:
+    """Сохранить кривую в текстовый файл в специальном формате.
+
+    Параметры
+    ----------
+    path:
+        Путь к выходному файлу.
+    X, Y:
+        Массивы значений осей.
+    precision:
+        Количество знаков после запятой при записи.
+
+    Исключения
+    ----------
+    ValueError
+        Если размеры ``X`` и ``Y`` различаются или нет точек.
+    """
+    x = np.asarray(X).ravel()
+    y = np.asarray(Y).ravel()
+    if x.shape != y.shape:
+        raise ValueError("X и Y должны иметь одинаковую длину")
+    n = x.size
+    if n == 0:
+        raise ValueError("Количество точек должно быть положительным")
+
+    fmt = f"{{:.{precision}f}} {{:.{precision}f}}\n"
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(f"{n}\n")
+        for xv, yv in zip(x, y):
+            fh.write(fmt.format(xv, yv))
+
+
+__all__ = ["export_curve_txt"]

--- a/tests/test_export_curve_txt.py
+++ b/tests/test_export_curve_txt.py
@@ -1,0 +1,31 @@
+import re
+
+import numpy as np
+import pytest
+
+from functions_for_tab2.exporting import export_curve_txt
+
+
+def test_export_curve_txt_structure(tmp_path):
+    x = np.array([0.123456, 1.234567])
+    y = np.array([2.345678, 3.456789])
+    path = tmp_path / "curve.txt"
+
+    export_curve_txt(str(path), x, y, precision=3)
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "2"
+    assert len(lines) == 3
+    pattern = re.compile(r"-?\d+\.\d{3} -?\d+\.\d{3}")
+    assert pattern.fullmatch(lines[1])
+    assert pattern.fullmatch(lines[2])
+
+
+def test_export_curve_txt_validation(tmp_path):
+    path = tmp_path / "curve.txt"
+
+    with pytest.raises(ValueError):
+        export_curve_txt(str(path), np.array([1.0]), np.array([]), precision=2)
+
+    with pytest.raises(ValueError):
+        export_curve_txt(str(path), np.array([]), np.array([]), precision=2)


### PR DESCRIPTION
## Summary
- реализован экспорт кривой в TXT с количеством точек и заданной точностью
- добавлены тесты на структуру и проверку входных данных

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a373e317b0832aa76d45d436366fa8