### PR TITLE
feat: add tolerance for segment stitching

### DIFF
--- a/functions_for_tab2/stitch.py
+++ b/functions_for_tab2/stitch.py
@@ -1,4 +1,10 @@
-"""Concatenate multiple segments into a continuous curve."""
+"""Concatenate multiple segments into a continuous curve.
+
+Функция склеивает несколько отдельных сегментов в одну непрерывную
+кривую.  При необходимости она выравнивает первую точку следующего
+сегмента по последней точке текущего сегмента, если их значения по
+соответствующей оси аргумента совпадают с заданной точностью.
+"""
 
 from __future__ import annotations
 
@@ -18,7 +24,30 @@ def stitch_segments(
     require_continuity: bool,
     tol: float = 1e-8,
 ) -> ComputedSegment:
-    """Concatenate segments into a single curve."""
+    """Concatenate segments into a single curve.
+
+    Parameters
+    ----------
+    segments:
+        Список сегментов, каждый из которых содержит массивы ``X`` и ``Y``.
+    primary_sequence:
+        Последовательность осей аргумента, используемых при построении
+        соответствующих сегментов (``"X"`` или ``"Y"``).
+    require_continuity:
+        Если ``True``, первая точка очередного сегмента будет приведена к
+        последней точке предыдущего по оси аргумента. Если разница по этой
+        оси меньше ``tol`` и обе координаты совпадают по значению, то
+        дублирующая точка исключается.
+    tol:
+        Допустимое расхождение между соседними сегментами. Значение по
+        умолчанию ``1e-8`` подобрано так, чтобы игнорировать накопленные
+        ошибки округления при вычислениях в числах двойной точности.
+
+    Returns
+    -------
+    ComputedSegment
+        Склеенный сегмент.
+    """
     if not segments:
         return ComputedSegment(X=np.array([], dtype=float), Y=np.array([], dtype=float))
     if len(segments) != len(primary_sequence):

--- a/tabs/tab2.py
+++ b/tabs/tab2.py
@@ -321,6 +321,7 @@ class Tab2Frame(ttk.Frame):
 
         control_frame = ttk.Frame(self)
         control_frame.place(x=800, y=520, width=640, height=40)
+        # Опция выравнивания соседних сегментов по оси аргумента
         self.stitch_var = tk.BooleanVar(value=True)
         ttk.Checkbutton(
             control_frame, text="Стыковать интервалы", variable=self.stitch_var

--- a/tests/test_stitch_segments.py
+++ b/tests/test_stitch_segments.py
@@ -39,3 +39,19 @@ def test_stitch_without_continuity():
 
     assert np.allclose(stitched.X, [0.0, 1.0, 2.0, 2.0 + 1e-9, 3.0, 4.0])
     assert np.allclose(stitched.Y, [0.0, 1.0, 4.0, 4.0, 9.0, 16.0])
+
+
+def test_stitch_with_primary_y_axis():
+    seg1 = ComputedSegment(
+        X=np.array([0.0, 1.0, 4.0]),
+        Y=np.array([0.0, 1.0, 2.0]),
+    )
+    seg2 = ComputedSegment(
+        X=np.array([4.0, 9.0, 16.0]),
+        Y=np.array([2.0 + 1e-9, 3.0, 4.0]),
+    )
+
+    stitched = stitch_segments([seg1, seg2], ["Y", "Y"], True, tol=1e-8)
+
+    assert np.allclose(stitched.X, [0.0, 1.0, 4.0, 9.0, 16.0])
+    assert np.allclose(stitched.Y, [0.0, 1.0, 2.0, 3.0, 4.0])


### PR DESCRIPTION
## Summary
- document tolerance handling in segment stitching
- clarify UI option for stitching intervals
- cover Y-axis stitching behavior with new tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4098f5fac832a94d739c422091d35