### PR TITLE
Аннотации типов для sort_options и create_tab1

### DIFF
--- a/tabs/constants.py
+++ b/tabs/constants.py
@@ -1,8 +1,20 @@
 # -*- coding: utf-8 -*-
 """Константы для вкладок приложения."""
 
+from collections.abc import Sequence
 
-def sort_options(options):
+
+def sort_options(options: Sequence[str]) -> list[str]:
+    """Сортирует список опций.
+
+    Параметры:
+        options: последовательность строк для упорядочивания.
+
+    Возвращает:
+        Отсортированный список, где «Нет» стоит первым,
+        а «Другое» — последним.
+    """
+
     first = ["Нет"] if "Нет" in options else []
     middle = sorted([opt for opt in options if opt not in ("Нет", "Другое")])
     last = ["Другое"] if "Другое" in options else []

--- a/tabs/tab1.py
+++ b/tabs/tab1.py
@@ -44,7 +44,16 @@ def on_combo_changeX_Y_labels(combo, entry, label_size, size_combo):
             size_combo.place_forget()
 
 
-def create_tab1(notebook):
+def create_tab1(notebook: ttk.Notebook) -> None:
+    """Создает первую вкладку для построения графика.
+
+    Параметры:
+        notebook: виджет, в который добавляется вкладка.
+
+    Возвращает:
+        None.
+    """
+
     # Создание первой вкладки
     tab1 = ttk.Frame(notebook)
     notebook.add(tab1, text="Создание изображения графика")


### PR DESCRIPTION
## Изменения
- добавлены аннотации типов и расширенный docstring для `sort_options`
- описаны параметры и возвращаемые значения `create_tab1`

## Проверки
- `black tabs/constants.py tabs/tab1.py`
- `python -m py_compile tabs/constants.py tabs/tab1.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a40dcf8ac0832a8dad6030fdb2b220