### PR TITLE
Оформление проекта как пакета и упрощение тестов

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "graphics"
+version = "0.1.0"
+description = "Graphics utility project"
+dependencies = [
+    "matplotlib",
+    "numpy",
+    "openpyxl",
+]
+
+[tool.flake8]
+max-line-length = 120
+
+[tool.ruff]
+line-length = 120

--- a/tests/test_combined_excel_ranges.py
+++ b/tests/test_combined_excel_ranges.py
@@ -1,9 +1,6 @@
 import tempfile
-import sys
-from pathlib import Path
 from openpyxl import Workbook
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from tabs.functions_for_tab1.curves_from_file.combined_curve import read_X_Y_from_combined
 
 

--- a/tests/test_combined_frequency_analysis.py
+++ b/tests/test_combined_frequency_analysis.py
@@ -1,8 +1,5 @@
 import tempfile
-import sys
-from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from tabs.functions_for_tab1.curves_from_file.combined_curve import read_X_Y_from_combined
 
 

--- a/tests/test_combined_text_ls_dyna_columns.py
+++ b/tests/test_combined_text_ls_dyna_columns.py
@@ -1,8 +1,5 @@
 import tempfile
-import sys
-from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from tabs.functions_for_tab1.curves_from_file.combined_curve import read_X_Y_from_combined
 
 

--- a/tests/test_dependent_values.py
+++ b/tests/test_dependent_values.py
@@ -1,11 +1,7 @@
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
 import pytest
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from functions_for_tab2.dependent import compute_dependent_values
 

--- a/tests/test_excel_single_range.py
+++ b/tests/test_excel_single_range.py
@@ -1,9 +1,6 @@
 import tempfile
-import sys
-from pathlib import Path
 from openpyxl import Workbook
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from tabs.functions_for_tab1.curves_from_file.excel_file import read_X_Y_from_excel
 
 

--- a/tests/test_grid_generation.py
+++ b/tests/test_grid_generation.py
@@ -1,10 +1,5 @@
-import sys
-from pathlib import Path
-
 import numpy as np
 import pytest
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from functions_for_tab2.grid import build_grid_manual, build_grid_uniform
 

--- a/tests/test_ls_dyna_file_with_header.py
+++ b/tests/test_ls_dyna_file_with_header.py
@@ -1,7 +1,5 @@
-import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from tabs.functions_for_tab1.curves_from_file.ls_dyna_file import read_X_Y_from_ls_dyna
 
 

--- a/tests/test_ls_dyna_invalid_file.py
+++ b/tests/test_ls_dyna_invalid_file.py
@@ -1,9 +1,8 @@
-import sys
 from pathlib import Path
 from unittest.mock import patch
+
 import pytest
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from tabs.functions_for_tab1.curves_from_file.ls_dyna_file import read_X_Y_from_ls_dyna
 
 

--- a/tests/test_new_axis_names.py
+++ b/tests/test_new_axis_names.py
@@ -1,6 +1,3 @@
-import sys
-from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 import pytest
 from tabs.tab1 import on_combo_changeX_Y_labels
 

--- a/tests/test_parsing_utils_read_pairs.py
+++ b/tests/test_parsing_utils_read_pairs.py
@@ -1,11 +1,9 @@
-import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from tabs.function_for_all_tabs.parsing_utils import read_pairs
 
 

--- a/tests/test_segment_builder.py
+++ b/tests/test_segment_builder.py
@@ -1,11 +1,6 @@
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
-import pytest
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from functions_for_tab2 import IntervalSpec
 from functions_for_tab2.segment_builder import build_segment

--- a/tests/test_stitch_segments.py
+++ b/tests/test_stitch_segments.py
@@ -1,9 +1,4 @@
-import sys
-from pathlib import Path
-
 import numpy as np
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from functions_for_tab2.models import ComputedSegment
 from functions_for_tab2.stitch import stitch_segments

--- a/tests/test_text_file_invalid_extension.py
+++ b/tests/test_text_file_invalid_extension.py
@@ -1,9 +1,6 @@
 import tempfile
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from tabs.functions_for_tab1.curves_from_file.text_file import read_X_Y_from_text_file
 
 


### PR DESCRIPTION
## Summary
- добавлен `pyproject.toml` для описания пакета и настроек линтеров
- тесты переписаны на обычные пакетные импорты вместо ручного `sys.path`

## Testing
- `ruff check tests`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a76f2188f8832a9c8156c5b41628ec