### PR TITLE
Добавлен универсальный адаптер чтения кривых

### DIFF
--- a/function_for_all_tabs/__init__.py
+++ b/function_for_all_tabs/__init__.py
@@ -2,6 +2,7 @@
 
 from .safe_eval import safe_eval_expr
 from .plotting_adapter import create_plot_canvas, plot_on_canvas
+from .readers import read_pairs_any
 from .validation import (
     ValidationError,
     EmptyDataError,
@@ -20,6 +21,7 @@ __all__ = [
     "safe_eval_expr",
     "create_plot_canvas",
     "plot_on_canvas",
+    "read_pairs_any",
     "ValidationError",
     "EmptyDataError",
     "InvalidFormatError",

--- a/function_for_all_tabs/readers.py
+++ b/function_for_all_tabs/readers.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, List, Tuple
+
+from tabs.functions_for_tab1.curves_from_file import (
+    read_X_Y_from_excel,
+    read_X_Y_from_ls_dyna,
+    read_X_Y_from_text_file,
+)
+
+
+def read_pairs_any(
+    path: str,
+    *,
+    read_excel: Callable[[dict], None] = read_X_Y_from_excel,
+    read_ls_dyna: Callable[[dict], None] = read_X_Y_from_ls_dyna,
+    read_text: Callable[[dict], None] = read_X_Y_from_text_file,
+) -> Tuple[List[float], List[float]]:
+    """Read ``(X, Y)`` pairs from a file of any supported format.
+
+    Parameters
+    ----------
+    path:
+        Путь к файлу данных.
+    read_excel, read_ls_dyna, read_text:
+        Функции чтения для форматов Excel, LS-DYNA и текстовых файлов.
+        Передаются как параметры для упрощения тестирования.
+    """
+    curve_info = {"curve_file": path}
+    suffix = Path(path).suffix.lower()
+    if suffix in {".xlsx", ".xlsm", ".csv"}:
+        read_excel(curve_info)
+    else:
+        try:
+            read_ls_dyna(curve_info)
+        except Exception:
+            read_text(curve_info)
+    return curve_info.get("X_values", []), curve_info.get("Y_values", [])
+
+
+__all__ = ["read_pairs_any"]

--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -2,11 +2,9 @@ from tkinter import filedialog, messagebox
 from pathlib import Path
 
 from tabs.function_for_all_tabs import create_plot
+from function_for_all_tabs import read_pairs_any
 from .curves_from_file import (
     read_X_Y_from_frequency_analysis,
-    read_X_Y_from_text_file,
-    read_X_Y_from_ls_dyna,
-    read_X_Y_from_excel,
     read_X_Y_from_combined,
 )
 
@@ -210,16 +208,15 @@ def save_file(entry_widget, format_widget, graph_info):
 
 
 def get_X_Y_data(curve_info):
-    if curve_info["curve_type"] == "Частотный анализ":
+    curve_type = curve_info.get("curve_type")
+    if curve_type == "Частотный анализ":
         read_X_Y_from_frequency_analysis(curve_info)
-    elif curve_info["curve_type"] == "Текстовой файл":
-        read_X_Y_from_text_file(curve_info)
-    elif curve_info["curve_type"] == "Файл кривой LS-Dyna":
-        read_X_Y_from_ls_dyna(curve_info)
-    elif curve_info["curve_type"] == "Excel файл":
-        read_X_Y_from_excel(curve_info)
-    elif curve_info["curve_type"] == "Комбинированный":
+    elif curve_type == "Комбинированный":
         read_X_Y_from_combined(curve_info)
+    else:
+        x_vals, y_vals = read_pairs_any(curve_info["curve_file"])
+        curve_info["X_values"] = list(x_vals)
+        curve_info["Y_values"] = list(y_vals)
 
 
 def generate_graph(


### PR DESCRIPTION
## Summary
- добавлен общий адаптер `read_pairs_any` для чтения пар значений из файлов разных форматов
- модуль `dependent` использует адаптер вместо локальной реализации
- чтение данных в построении графиков таба 1 унифицировано через `read_pairs_any`

## Testing
- `PYTHONPATH=. pytest tests/test_dependent_values.py -k test_from_file_uses_tab1_reader -q` *(ошибка: No module named 'PyQt5')*
- `pip install PyQt5` *(ошибка: Could not find a version that satisfies the requirement PyQt5)*

------
https://chatgpt.com/codex/tasks/task_e_68a77a56a468832a9690c6a96621fc11