### PR TITLE
Handle text files directly and simplify LS-DYNA errors

### DIFF
--- a/function_for_all_tabs/readers.py
+++ b/function_for_all_tabs/readers.py
@@ -31,6 +31,8 @@ def read_pairs_any(
     suffix = Path(path).suffix.lower()
     if suffix in {".xlsx", ".xlsm", ".csv"}:
         read_excel(curve_info)
+    elif suffix == ".txt":
+        read_text(curve_info)
     else:
         try:
             read_ls_dyna(curve_info)

--- a/tabs/functions_for_tab1/curves_from_file/ls_dyna_file.py
+++ b/tabs/functions_for_tab1/curves_from_file/ls_dyna_file.py
@@ -9,8 +9,7 @@ def read_X_Y_from_ls_dyna(curve_info):
 
     Функция проверяет несколько первых строк файла на наличие маркеров
     формата LS-DYNA (``LS-DYNA``, ``*KEYWORD`` или ``Curveplot``). Если ни
-    один из них не найден, пользователю отображается сообщение об ошибке и
-    выбрасывается исключение :class:`ValueError`.
+    один из них не найден, выбрасывается исключение :class:`ValueError`.
 
     Строки, не содержащие хотя бы двух числовых значений (заголовки,
     комментарии и т.п.), пропускаются без генерации сообщения об ошибке.
@@ -24,7 +23,6 @@ def read_X_Y_from_ls_dyna(curve_info):
             markers = ("LS-DYNA", "*KEYWORD", "Curveplot")
             if not any(any(marker in line for marker in markers) for line in header_lines):
                 logger.error("Файл '%s' не является файлом LS-DYNA.", path)
-                messagebox.showerror("Ошибка", f"Файл {path} не является файлом LS-DYNA")
                 raise ValueError("Файл не соответствует формату LS-DYNA")
             file.seek(0)
             for raw_line in file:


### PR DESCRIPTION
## Summary
- Call text parser directly for `.txt` files in reader
- Remove message box for non-LS-DYNA files and raise `ValueError`

## Testing
- `ruff check` *(fails: Module level import not at top of file, unused imports)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'tabs')*

------
https://chatgpt.com/codex/tasks/task_e_68a77d463b28832aa182d95ff5ef7d3d