### PR TITLE
feat: expose pair parsing utility

### DIFF
--- a/tabs/function_for_all_tabs/__init__.py
+++ b/tabs/function_for_all_tabs/__init__.py
@@ -1,7 +1,7 @@
 """Утилиты, общие для всех вкладок."""
 
 from .plotting import create_plot
-from .parsing_utils import read_pairs, parse_numbers
+from .parsing_utils import read_pairs, parse_numbers, parse_pairs_text
 from .plotting_adapter import create_plot_canvas, plot_on_canvas
 from .readers import read_pairs_any
 from .safe_eval import safe_eval_expr
@@ -23,6 +23,7 @@ __all__ = [
     "create_plot",
     "read_pairs",
     "parse_numbers",
+    "parse_pairs_text",
     "create_plot_canvas",
     "plot_on_canvas",
     "read_pairs_any",

--- a/tabs/function_for_all_tabs/parsing_utils.py
+++ b/tabs/function_for_all_tabs/parsing_utils.py
@@ -43,5 +43,21 @@ def parse_numbers(text: str) -> np.ndarray:
     return np.asarray(numbers, dtype=float)
 
 
-__all__ = ["read_pairs", "parse_numbers"]
+def parse_pairs_text(text: str) -> Tuple[np.ndarray, np.ndarray]:
+    """Parse ``(x, y)`` pairs from a multiline string."""
+    xs: List[float] = []
+    ys: List[float] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        numbers = parse_numbers(line)
+        if numbers.size < 2:
+            raise InvalidFormatError(f"Некорректные данные в строке: {line}")
+        xs.append(float(numbers[0]))
+        ys.append(float(numbers[1]))
+    return np.asarray(xs, dtype=float), np.asarray(ys, dtype=float)
+
+
+__all__ = ["read_pairs", "parse_numbers", "parse_pairs_text"]
 

--- a/tabs/functions_for_tab2/dependent.py
+++ b/tabs/functions_for_tab2/dependent.py
@@ -12,30 +12,14 @@ from tabs.function_for_all_tabs.validation import (
     SizeMismatchError,
 )
 from tabs.function_for_all_tabs.parsing_utils import parse_numbers
+from tabs.function_for_all_tabs import parse_pairs_text, read_pairs_any
 from tabs.functions_for_tab1.curves_from_file import (
     read_X_Y_from_excel,
     read_X_Y_from_ls_dyna,
     read_X_Y_from_text_file,
 )
-from tabs.function_for_all_tabs import read_pairs_any
 
 Array = np.ndarray
-
-
-def _parse_manual_pairs(text: str) -> Tuple[Array, Array]:
-    """Parse ``(x, y)`` pairs from a multiline string."""
-    xs: list[float] = []
-    ys: list[float] = []
-    for raw_line in text.splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-        numbers = parse_numbers(line)
-        if numbers.size < 2:
-            raise InvalidFormatError(f"Некорректные данные в строке: {line}")
-        xs.append(float(numbers[0]))
-        ys.append(float(numbers[1]))
-    return np.asarray(xs, dtype=float), np.asarray(ys, dtype=float)
 
 
 
@@ -75,7 +59,7 @@ def compute_dependent_values(
         return np.asarray(xs, dtype=float), np.asarray(ys, dtype=float)
 
     if dep_mode == "manual_pairs":
-        return _parse_manual_pairs(manual_pairs_text)
+        return parse_pairs_text(manual_pairs_text)
 
     raise InvalidFormatError(f"Неизвестный режим: {dep_mode}")
 

--- a/tabs/tab2.py
+++ b/tabs/tab2.py
@@ -4,10 +4,13 @@ import json
 import tkinter as tk
 from tkinter import ttk, messagebox, filedialog
 
-from tabs.function_for_all_tabs import create_plot_canvas, plot_on_canvas
+from tabs.function_for_all_tabs import (
+    create_plot_canvas,
+    plot_on_canvas,
+    parse_pairs_text,
+)
 from tabs.function_for_all_tabs.validation import ValidationError, ensure_min_length
 from tabs.function_for_all_tabs.parsing_utils import parse_numbers
-from tabs.functions_for_tab2.dependent import _parse_manual_pairs
 from tabs.functions_for_tab2 import ComputedSegment, IntervalSpec, stitch_segments
 from tabs.functions_for_tab2.presets import PRESETS
 from tabs.functions_for_tab2.exporting import export_curve_txt
@@ -316,7 +319,7 @@ class IntervalEditor(ttk.Frame):
     ) -> None:
         text = widget.get("1.0", tk.END).strip()
         try:
-            xs, _ = _parse_manual_pairs(text)
+            xs, _ = parse_pairs_text(text)
             ensure_min_length(xs, min_count, name="пар")
             label.config(text=f"Распознано: {len(xs)} пар", foreground="green")
             widget.configure(background=self._text_bg)


### PR DESCRIPTION
## Summary
- add parse_pairs_text to parsing_utils and expose in function_for_all_tabs
- switch manual pair parsing to parse_pairs_text in tab2 and dependent utilities

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'PyQt5')*


------
https://chatgpt.com/codex/tasks/task_e_68a780ca65a4832aaf2cbfb4ed24e169