### PR TITLE
Строгая проверка текстовых файлов

### DIFF
--- a/tabs/__init__.py
+++ b/tabs/__init__.py
@@ -1,7 +1,24 @@
 """Модули вкладок графического интерфейса."""
 
-from .tab1 import create_tab1
-from .tab2 import create_tab2
-from .tab3 import create_tab3
+# Импортируем функции создания вкладок лениво, чтобы избежать зависимости
+# от графических библиотек при простом импорте пакета ``tabs``.
 
 __all__ = ["create_tab1", "create_tab2", "create_tab3"]
+
+
+def create_tab1(*args, **kwargs):  # pragma: no cover - простая обёртка
+    from .tab1 import create_tab1 as _create_tab1
+
+    return _create_tab1(*args, **kwargs)
+
+
+def create_tab2(*args, **kwargs):  # pragma: no cover - простая обёртка
+    from .tab2 import create_tab2 as _create_tab2
+
+    return _create_tab2(*args, **kwargs)
+
+
+def create_tab3(*args, **kwargs):  # pragma: no cover - простая обёртка
+    from .tab3 import create_tab3 as _create_tab3
+
+    return _create_tab3(*args, **kwargs)

--- a/tabs/functions_for_tab1/curves_from_file/text_file.py
+++ b/tabs/functions_for_tab1/curves_from_file/text_file.py
@@ -9,9 +9,12 @@ def read_X_Y_from_text_file(curve_info):
     try:
         path = Path(curve_info['curve_file'])
         suffix = path.suffix.lower()
-        if suffix and suffix != '.txt':
-            logger.error("Неподдерживаемый формат файла: %s", suffix)
-            messagebox.showerror("Ошибка", f"Ожидался файл с расширением .txt, получен {suffix}")
+        if suffix != '.txt':
+            logger.error("Неподдерживаемый формат файла: %s", suffix or '<без расширения>')
+            messagebox.showerror(
+                "Ошибка",
+                f"Ожидался файл с расширением .txt, получен {suffix or '<без расширения>'}"
+            )
             return
 
         X_data = []
@@ -22,7 +25,7 @@ def read_X_Y_from_text_file(curve_info):
                 if not line:
                     continue
                 parts = line.replace(',', ' ').split()
-                if len(parts) < 2:
+                if len(parts) != 2:
                     logger.error("Некорректная строка данных: %s", line)
                     messagebox.showerror("Ошибка", f"Некорректные данные в строке: {line}")
                     return

--- a/tests/test_parsing_utils_read_pairs.py
+++ b/tests/test_parsing_utils_read_pairs.py
@@ -29,6 +29,17 @@ def test_read_pairs_invalid_line():
     Path(path).unlink()
 
 
+def test_read_pairs_three_numbers_line():
+    with tempfile.NamedTemporaryFile('w', suffix='.txt', delete=False) as tmp:
+        tmp.write('1 2 3\n')
+        path = tmp.name
+
+    with patch('tabs.functions_for_tab1.curves_from_file.text_file.messagebox.showerror'), \
+            pytest.raises(ValueError):
+        read_pairs(path)
+    Path(path).unlink()
+
+
 def test_read_pairs_missing_file():
     missing = Path('nonexistent_file.txt')
     with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
## Summary
- Проверка расширения .txt с сообщением об ошибке при другом или отсутствии
- Жёсткая проверка строк: каждая должна содержать ровно два значения
- Тест на строку с тремя числами в текстовом файле
- Ленивые импорты вкладок, чтобы избежать зависимости от GUI при импорте пакета

## Testing
- `python -m pytest tests/test_parsing_utils_read_pairs.py tests/test_text_file_invalid_extension.py` (ошибка: ModuleNotFoundError: No module named 'PyQt5')


------
https://chatgpt.com/codex/tasks/task_e_68a786894140832ab5340e145d8cd5af