### PR TITLE
Validate frequency analysis input

### DIFF
--- a/tests/test_combined_frequency_analysis.py
+++ b/tests/test_combined_frequency_analysis.py
@@ -4,7 +4,7 @@ from tabs.functions_for_tab1.curves_from_file.combined_curve import read_X_Y_fro
 
 
 def _create_temp_file(content: str):
-    tmp = tempfile.NamedTemporaryFile('w+', delete=False)
+    tmp = tempfile.NamedTemporaryFile('w+', suffix='.txt', delete=False)
     tmp.write(content)
     tmp.flush()
     return tmp

--- a/tests/test_frequency_analysis_invalid_file.py
+++ b/tests/test_frequency_analysis_invalid_file.py
@@ -1,0 +1,41 @@
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from tabs.functions_for_tab1.curves_from_file.frequency_analysis import (
+    read_X_Y_from_frequency_analysis,
+)
+
+
+def _curve_info(path: str):
+    return {
+        'curve_file': path,
+        'curve_typeXF': 'Время',
+        'curve_typeYF': 'Частота',
+        'curve_typeXF_type': 'X',
+        'curve_typeYF_type': 'X',
+    }
+
+
+def test_frequency_analysis_invalid_extension():
+    with tempfile.NamedTemporaryFile('w', suffix='.csv', delete=False) as tmp:
+        tmp.write('data')
+        tmp_path = tmp.name
+    curve_info = _curve_info(tmp_path)
+    with patch('tabs.functions_for_tab1.curves_from_file.frequency_analysis.messagebox.showerror'):
+        read_X_Y_from_frequency_analysis(curve_info)
+    assert 'X_values' not in curve_info
+    assert 'Y_values' not in curve_info
+
+
+def test_frequency_analysis_missing_header():
+    with tempfile.NamedTemporaryFile('w', suffix='.txt', delete=False) as tmp:
+        tmp.write('no headers here\n')
+        tmp_path = tmp.name
+    curve_info = _curve_info(tmp_path)
+    with patch('tabs.functions_for_tab1.curves_from_file.frequency_analysis.messagebox.showerror'):
+        with pytest.raises(ValueError):
+            read_X_Y_from_frequency_analysis(curve_info)
+    assert 'X_values' not in curve_info
+    assert 'Y_values' not in curve_info


### PR DESCRIPTION
## Summary
- ensure frequency analysis reads only .txt files and contains required headers
- add tests for invalid extensions and missing headers

## Testing
- `PYTHONPATH=. pytest tests/test_frequency_analysis_invalid_file.py tests/test_combined_frequency_analysis.py tests/test_text_file_invalid_extension.py`
- `PYTHONPATH=. pytest` *(fails: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_68a788b46360832aa4a5641628b321aa