### PR TITLE
Показ ошибки при чтении неправильного файла LS-DYNA

### DIFF
--- a/tabs/functions_for_tab1/curves_from_file/ls_dyna_file.py
+++ b/tabs/functions_for_tab1/curves_from_file/ls_dyna_file.py
@@ -40,12 +40,18 @@ def read_X_Y_from_ls_dyna(curve_info):
                         logger.error(
                             "Файл '%s' не является файлом LS-DYNA.", path
                         )
+                        messagebox.showerror(
+                            "Ошибка", f"Файл {path} не соответствует формату LS-DYNA"
+                        )
                         raise ValueError("Файл не соответствует формату LS-DYNA")
                     # Считываем строки после первой как источник точек
                     file.readline()  # пропускаем строку с количеством точек
                     lines_iterator = (file.readline() for _ in range(expected_points))
                 else:
                     logger.error("Файл '%s' не является файлом LS-DYNA.", path)
+                    messagebox.showerror(
+                        "Ошибка", f"Файл {path} не соответствует формату LS-DYNA"
+                    )
                     raise ValueError("Файл не соответствует формату LS-DYNA")
 
             for raw_line in lines_iterator:


### PR DESCRIPTION
## Summary
- Показ `messagebox.showerror` перед выбросом `ValueError` при попытке открыть файл неформата LS-DYNA
- Очистка `curve_info` подтверждена тестами

## Testing
- `PYTHONPATH=. pytest tests/test_ls_dyna_invalid_file.py tests/test_ls_dyna_file_without_markers.py tests/test_ls_dyna_file_with_header.py -q`
- `PYTHONPATH=. pytest -q` *(ошибка: ModuleNotFoundError: No module named 'PyQt5')*


------
https://chatgpt.com/codex/tasks/task_e_68a78ab81424832a95f11b289125a7ea