### PR TITLE
Restore direct canvas redraw on width change

### DIFF
--- a/ui/plot_editor.py
+++ b/ui/plot_editor.py
@@ -128,7 +128,7 @@ class PlotEditor(QWidget):
 
     def _update_width(self, line, width: int) -> None:
         line.set_linewidth(width)
-        self._refresh_legend()
+        self.canvas.draw()
 
     # ------------------------------------------------------------------
     # Saving

--- a/widgets/plot_editor.py
+++ b/widgets/plot_editor.py
@@ -98,4 +98,4 @@ class PlotEditor(ttk.Frame):
 
     def _update_width(self, line, width: float) -> None:
         line.set_linewidth(width)
-        self._refresh_legend()
+        self.canvas.draw()


### PR DESCRIPTION
## Summary
- Call `canvas.draw()` directly when updating line width in UI PlotEditor
- Call `canvas.draw()` directly when updating line width in widgets PlotEditor

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt5')*
- `pip install PyQt5==5.15.10` *(fails: Could not find a version that satisfies the requirement; proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a78e48f340832ab8a6757f0e3240ed