### PR TITLE
Refactor title processing for tab1

### DIFF
--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -13,153 +13,156 @@ from .curves_from_file import (
 # Хранит информацию о последнем построенном графике для последующего сохранения
 last_graph = {}
 
+title_mapping = {
+    "Время": {
+        "Русский": "Время $t$",
+        "Английский": "Time $t$",
+    },
+    "Перемещение по X": {
+        "Русский": "Перемещение $x$",
+        "Английский": "Displacement $x$",
+    },
+    "Перемещение по Y": {
+        "Русский": "Перемещение $y$",
+        "Английский": "Displacement $y$",
+    },
+    "Перемещение по Z": {
+        "Русский": "Перемещение $z$",
+        "Английский": "Displacement $z$",
+    },
+    "Удлинение": {
+        "Русский": r"Удлинение $\Delta l$",
+        "Английский": r"Elongation $\Delta l$",
+    },
+    "Удлинение по X": {
+        "Русский": r"Удлинение $\Delta l_x$",
+        "Английский": r"Elongation $\Delta l_x$",
+    },
+    "Удлинение по Y": {
+        "Русский": r"Удлинение $\Delta l_y$",
+        "Английский": r"Elongation $\Delta l_y$",
+    },
+    "Удлинение по Z": {
+        "Русский": r"Удлинение $\Delta l_z$",
+        "Английский": r"Elongation $\Delta l_z$",
+    },
+    "Деформация": {
+        "Русский": r"Деформация $\varepsilon$",
+        "Английский": r"Strain $\varepsilon$",
+    },
+    "Пластическая деформация": {
+        "Русский": r"Пластическая деформация $\varepsilon_p$",
+        "Английский": r"Plastic strain $\varepsilon_p$",
+    },
+    "Сила": {
+        "Русский": "Сила $F$",
+        "Английский": "Force $F$",
+    },
+    "Продольная сила": {
+        "Русский": "Продольная сила $N$",
+        "Английский": "Axial force $N$",
+    },
+    "Поперечная сила": {
+        "Русский": "Поперечная сила $Q$",
+        "Английский": "Shear force $Q$",
+    },
+    "Поперечная сила по Y": {
+        "Русский": "Поперечная сила $Q_y$",
+        "Английский": "Shear force $Q_y$",
+    },
+    "Поперечная сила по Z": {
+        "Русский": "Поперечная сила $Q_z$",
+        "Английский": "Shear force $Q_z$",
+    },
+    "Масса": {
+        "Русский": "Масса $m$",
+        "Английский": "Mass $m$",
+    },
+    "Напряжение": {
+        "Русский": r"Напряжение $\sigma$",
+        "Английский": r"Stress $\sigma$",
+    },
+    "Интенсивность напряжений": {
+        "Русский": r"Интенсивность напряжений $\sigma_i$",
+        "Английский": r"Stress intensity $\sigma_i$",
+    },
+    "Нормальное напряжение X": {
+        "Русский": r"Нормальное напряжение $\sigma_x$",
+        "Английский": r"Normal stress $\sigma_x$",
+    },
+    "Нормальное напряжение Y": {
+        "Русский": r"Нормальное напряжение $\sigma_y$",
+        "Английский": r"Normal stress $\sigma_y$",
+    },
+    "Нормальное напряжение Z": {
+        "Русский": r"Нормальное напряжение $\sigma_z$",
+        "Английский": r"Normal stress $\sigma_z$",
+    },
+    "Касательное напряжение XY": {
+        "Русский": r"Касательное напряжение $\tau_{xy}$",
+        "Английский": r"Shear stress $\tau_{xy}$",
+    },
+    "Касательное напряжение XZ": {
+        "Русский": r"Касательное напряжение $\tau_{xz}$",
+        "Английский": r"Shear stress $\tau_{xz}$",
+    },
+    "Касательное напряжение YX": {
+        "Русский": r"Касательное напряжение $\tau_{yx}$",
+        "Английский": r"Shear stress $\tau_{yx}$",
+    },
+    "Касательное напряжение YZ": {
+        "Русский": r"Касательное напряжение $\tau_{yz}$",
+        "Английский": r"Shear stress $\tau_{yz}$",
+    },
+    "Касательное напряжение ZX": {
+        "Русский": r"Касательное напряжение $\tau_{zx}$",
+        "Английский": r"Shear stress $\tau_{zx}$",
+    },
+    "Касательное напряжение ZY": {
+        "Русский": r"Касательное напряжение $\tau_{zy}$",
+        "Английский": r"Shear stress $\tau_{zy}$",
+    },
+    "Крутящий момент Mx": {
+        "Русский": "Крутящий момент $M_x$",
+        "Английский": "Torque $M_x$",
+    },
+    "Изгибающий момент Mx": {
+        "Русский": "Изгибающий момент $M_x$",
+        "Английский": "Bending moment $M_x$",
+    },
+    "Изгибающий момент My": {
+        "Русский": "Изгибающий момент $M_y$",
+        "Английский": "Bending moment $M_y$",
+    },
+    "Изгибающий момент Mz": {
+        "Русский": "Изгибающий момент $M_z$",
+        "Английский": "Bending moment $M_z$",
+    },
+    "Частота 1": {
+        "Русский": "Частота ${{f}}_{{\\mathit{1}}}$",
+        "Английский": "Frequency ${{f}}_{{\\mathit{1}}}$",
+    },
+    "Частота 2": {
+        "Русский": "Частота ${{f}}_{{\\mathit{2}}}$",
+        "Английский": "Frequency ${{f}}_{{\\mathit{2}}}$",
+    },
+    "Частота 3": {
+        "Русский": "Частота ${{f}}_{{\\mathit{3}}}$",
+        "Английский": "Frequency ${{f}}_{{\\mathit{3}}}$",
+    },
+}
 
-class AxisTitleProcessor:
-    def __init__(self, combo_title, combo_size, entry_title=None, language="Русский"):
+
+class TitleProcessor:
+    def __init__(self, combo_title, combo_size=None, entry_title=None, language="Русский"):
         self.combo_title = combo_title
         self.combo_size = combo_size
         self.entry_title = entry_title
         self.language = language
-        self.title_mapping = {
-            "Время": {
-                "Русский": "Время $t$",
-                "Английский": "Time $t$",
-            },
-            "Перемещение по X": {
-                "Русский": "Перемещение $x$",
-                "Английский": "Displacement $x$",
-            },
-            "Перемещение по Y": {
-                "Русский": "Перемещение $y$",
-                "Английский": "Displacement $y$",
-            },
-            "Перемещение по Z": {
-                "Русский": "Перемещение $z$",
-                "Английский": "Displacement $z$",
-            },
-            "Удлинение": {
-                "Русский": r"Удлинение $\Delta l$",
-                "Английский": r"Elongation $\Delta l$",
-            },
-            "Удлинение по X": {
-                "Русский": r"Удлинение $\Delta l_x$",
-                "Английский": r"Elongation $\Delta l_x$",
-            },
-            "Удлинение по Y": {
-                "Русский": r"Удлинение $\Delta l_y$",
-                "Английский": r"Elongation $\Delta l_y$",
-            },
-            "Удлинение по Z": {
-                "Русский": r"Удлинение $\Delta l_z$",
-                "Английский": r"Elongation $\Delta l_z$",
-            },
-            "Деформация": {
-                "Русский": r"Деформация $\varepsilon$",
-                "Английский": r"Strain $\varepsilon$",
-            },
-            "Пластическая деформация": {
-                "Русский": r"Пластическая деформация $\varepsilon_p$",
-                "Английский": r"Plastic strain $\varepsilon_p$",
-            },
-            "Сила": {
-                "Русский": "Сила $F$",
-                "Английский": "Force $F$",
-            },
-            "Продольная сила": {
-                "Русский": "Продольная сила $N$",
-                "Английский": "Axial force $N$",
-            },
-            "Поперечная сила": {
-                "Русский": "Поперечная сила $Q$",
-                "Английский": "Shear force $Q$",
-            },
-            "Поперечная сила по Y": {
-                "Русский": "Поперечная сила $Q_y$",
-                "Английский": "Shear force $Q_y$",
-            },
-            "Поперечная сила по Z": {
-                "Русский": "Поперечная сила $Q_z$",
-                "Английский": "Shear force $Q_z$",
-            },
-            "Масса": {
-                "Русский": "Масса $m$",
-                "Английский": "Mass $m$",
-            },
-            "Напряжение": {
-                "Русский": r"Напряжение $\sigma$",
-                "Английский": r"Stress $\sigma$",
-            },
-            "Интенсивность напряжений": {
-                "Русский": r"Интенсивность напряжений $\sigma_i$",
-                "Английский": r"Stress intensity $\sigma_i$",
-            },
-            "Нормальное напряжение X": {
-                "Русский": r"Нормальное напряжение $\sigma_x$",
-                "Английский": r"Normal stress $\sigma_x$",
-            },
-            "Нормальное напряжение Y": {
-                "Русский": r"Нормальное напряжение $\sigma_y$",
-                "Английский": r"Normal stress $\sigma_y$",
-            },
-            "Нормальное напряжение Z": {
-                "Русский": r"Нормальное напряжение $\sigma_z$",
-                "Английский": r"Normal stress $\sigma_z$",
-            },
-            "Касательное напряжение XY": {
-                "Русский": r"Касательное напряжение $\tau_{xy}$",
-                "Английский": r"Shear stress $\tau_{xy}$",
-            },
-            "Касательное напряжение XZ": {
-                "Русский": r"Касательное напряжение $\tau_{xz}$",
-                "Английский": r"Shear stress $\tau_{xz}$",
-            },
-            "Касательное напряжение YX": {
-                "Русский": r"Касательное напряжение $\tau_{yx}$",
-                "Английский": r"Shear stress $\tau_{yx}$",
-            },
-            "Касательное напряжение YZ": {
-                "Русский": r"Касательное напряжение $\tau_{yz}$",
-                "Английский": r"Shear stress $\tau_{yz}$",
-            },
-            "Касательное напряжение ZX": {
-                "Русский": r"Касательное напряжение $\tau_{zx}$",
-                "Английский": r"Shear stress $\tau_{zx}$",
-            },
-            "Касательное напряжение ZY": {
-                "Русский": r"Касательное напряжение $\tau_{zy}$",
-                "Английский": r"Shear stress $\tau_{zy}$",
-            },
-            "Крутящий момент Mx": {
-                "Русский": "Крутящий момент $M_x$",
-                "Английский": "Torque $M_x$",
-            },
-            "Изгибающий момент Mx": {
-                "Русский": "Изгибающий момент $M_x$",
-                "Английский": "Bending moment $M_x$",
-            },
-            "Изгибающий момент My": {
-                "Русский": "Изгибающий момент $M_y$",
-                "Английский": "Bending moment $M_y$",
-            },
-            "Изгибающий момент Mz": {
-                "Русский": "Изгибающий момент $M_z$",
-                "Английский": "Bending moment $M_z$",
-            },
-            "Частота 1": {
-                "Русский": "Частота ${{f}}_{{\\mathit{1}}}$",
-                "Английский": "Frequency ${{f}}_{{\\mathit{1}}}$",
-            },
-            "Частота 2": {
-                "Русский": "Частота ${{f}}_{{\\mathit{2}}}$",
-                "Английский": "Frequency ${{f}}_{{\\mathit{2}}}$",
-            },
-            "Частота 3": {
-                "Русский": "Частота ${{f}}_{{\\mathit{3}}}$",
-                "Английский": "Frequency ${{f}}_{{\\mathit{3}}}$",
-            },
-        }
 
     def _get_units(self):
+        if self.combo_size is None:
+            return ""
         unit = self.combo_size.get()
         if unit in ("", "—"):
             return ""
@@ -167,17 +170,16 @@ class AxisTitleProcessor:
 
     def _get_title(self):
         selection = self.combo_title.get()
-        return self.title_mapping.get(selection, {}).get(self.language, selection)
+        return title_mapping.get(selection, {}).get(self.language, selection)
 
     def get_processed_title(self):
         selection = self.combo_title.get()
-        if selection == "Другое":
+        if selection in ("Другое", ""):
             return self.entry_title.get() if self.entry_title else ""
         if selection == "Нет":
             return ""
         title = self._get_title()
         return f"{title}{self._get_units()}"
-
 
 def save_file(entry_widget, format_widget, graph_info):
 
@@ -243,18 +245,15 @@ def generate_graph(
 
     # Очистка предыдущего графика
     ax.clear()
-    # Определяем заголовок графика
-    if combo_title.get() == "" and entry_title_custom is not None:
-        title = entry_title_custom.get()
-    else:
-        title = combo_title.get()
     language = combo_language.get() or "Русский"
-    xlabel_processor = AxisTitleProcessor(
+    title_processor = TitleProcessor(combo_title, entry_title=entry_title_custom, language=language)
+    xlabel_processor = TitleProcessor(
         combo_titleX, combo_titleX_size, entry_titleX, language
     )
-    ylabel_processor = AxisTitleProcessor(
+    ylabel_processor = TitleProcessor(
         combo_titleY, combo_titleY_size, entry_titleY, language
     )
+    title = title_processor.get_processed_title()
     xlabel = xlabel_processor.get_processed_title()
     ylabel = ylabel_processor.get_processed_title()
 

--- a/tabs/tab1.py
+++ b/tabs/tab1.py
@@ -12,13 +12,6 @@ from ui import constants as ui_const
 logger = logging.getLogger(__name__)
 
 
-# Набор готовых заголовков графиков
-PRESET_TITLES = [
-    "График зависимости",
-    "Диаграмма результатов",
-]
-
-
 def on_title_combo_change(
     combo: ttk.Combobox, entry: tk.Entry, title_var: tk.StringVar
 ) -> None:
@@ -176,7 +169,7 @@ def create_tab1(notebook: ttk.Notebook) -> None:
     title_var = tk.StringVar()
     combo_title = ttk.Combobox(
         input_frame,
-        values=PRESET_TITLES + ["Другое"],
+        values=PHYSICAL_QUANTITIES,
         state="readonly",
         textvariable=title_var,
     )


### PR DESCRIPTION
## Summary
- refactor AxisTitleProcessor into generic TitleProcessor with shared title mapping
- use TitleProcessor for graph title and axis labels
- drop PRESET_TITLES and populate graph title combo from PHYSICAL_QUANTITIES

## Testing
- `PYTHONPATH=. pytest` *(fails: No module named 'PyQt5')*
- `pip install PyQt5` *(fails: Could not find a version that satisfies the requirement PyQt5)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ecb401ac832a9d4e31e800a000e9