### PR TITLE
Использование Times New Roman для математических символов

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -4,6 +4,8 @@ import matplotlib.pyplot as plt
 def configure_matplotlib():
     """Configure global matplotlib settings used across the application."""
     plt.rcParams['font.family'] = 'Times New Roman'
+    plt.rcParams['mathtext.fontset'] = 'custom'
+    plt.rcParams['mathtext.rm'] = 'Times New Roman'
     plt.rcParams['font.size'] = 14  # Общий размер шрифта
     plt.rcParams['axes.titlesize'] = 14  # Размер шрифта для заголовков осей
     plt.rcParams['axes.labelsize'] = 14  # Размер шрифта для подписей осей


### PR DESCRIPTION
## Summary
- Настроены параметры matplotlib так, чтобы mathtext использовал шрифт Times New Roman.

## Testing
- `pytest -q` (падает: ModuleNotFoundError: No module named 'tabs')

------
https://chatgpt.com/codex/tasks/task_e_68a7f1defe5c832a8663886bde32d16d