### PR TITLE
Настройка математических шрифтов

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -6,6 +6,10 @@ def configure_matplotlib():
     plt.rcParams['font.family'] = 'Times New Roman'
     plt.rcParams['mathtext.fontset'] = 'custom'
     plt.rcParams['mathtext.rm'] = 'Times New Roman'
+    plt.rcParams['mathtext.it'] = 'Times New Roman:italic'
+    plt.rcParams['mathtext.bf'] = 'Times New Roman:bold'
+    plt.rcParams['mathtext.sf'] = 'Times New Roman'
+    plt.rcParams['mathtext.tt'] = 'Times New Roman'
     plt.rcParams['font.size'] = 14  # Общий размер шрифта
     plt.rcParams['axes.titlesize'] = 14  # Размер шрифта для заголовков осей
     plt.rcParams['axes.labelsize'] = 14  # Размер шрифта для подписей осей


### PR DESCRIPTION
## Summary
- добавлены настройки курсивного, жирного, без засечек и моноширинного математического текста для Times New Roman
- подтверждён вызов `configure_matplotlib()` перед построением графиков

## Testing
- `pytest` *(ошибка: ModuleNotFoundError: No module named 'tabs')*
- `python - <<'PY' ...` *(шрифт Times New Roman не найден, используется DejaVu Sans)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fde1525c832ab34dd6b446f32a3f