### PR TITLE
Добавить тест на корректность mathtext-подписей

### DIFF
--- a/tests/test_labels_mathtext.py
+++ b/tests/test_labels_mathtext.py
@@ -1,0 +1,17 @@
+from matplotlib.mathtext import MathTextParser
+
+import pytest
+
+from tabs.constants import TITLE_TRANSLATIONS
+
+
+parser = MathTextParser("agg")
+
+
+def test_all_titles_mathtext_parsable():
+    for quantity, translations in TITLE_TRANSLATIONS.items():
+        for lang, text in translations.items():
+            try:
+                parser.parse(text)
+            except Exception as exc:  # pragma: no cover - ошибка приводит к падению теста
+                pytest.fail(f"Ошибка парсинга '{quantity}' ({lang}): {exc}")


### PR DESCRIPTION
## Summary
- добавить тест, проверяющий разбор всех подписей из `TITLE_TRANSLATIONS`

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8d18e94d4832aa9313ad20c97a2fa