### PR TITLE
Log exceptions and notify users

### DIFF
--- a/tabs/tab1.py
+++ b/tabs/tab1.py
@@ -1,6 +1,6 @@
 import logging
 import tkinter as tk  # Alias for Tk functionality
-from tkinter import ttk
+from tkinter import ttk, messagebox
 from typing import List, Tuple
 from .functions_for_tab1 import update_curves, generate_graph, save_file
 from .functions_for_tab1.plotting import last_graph
@@ -387,8 +387,12 @@ def create_tab1(notebook: ttk.Notebook) -> None:
                 editor_visible["shown"] = True
             logger.info("График построен успешно")
         except Exception as exc:
-            logger.error("Ошибка при построении графика: %s", exc)
-            raise
+            logger.exception("Ошибка при построении графика")
+            messagebox.showerror(
+                "Ошибка",
+                f"Не удалось построить график:\n{exc}\n"
+                "Проверьте введённые данные и попробуйте снова.",
+            )
 
     # Кнопка построения графика
     btn_generate_graph = ttk.Button(tab1, text="Построить график", command=build_graph)

--- a/tabs/tab2.py
+++ b/tabs/tab2.py
@@ -1,6 +1,7 @@
 """Каркас второй вкладки приложения."""
 
 import json
+import logging
 import tkinter as tk
 from tkinter import ttk, messagebox, filedialog
 
@@ -17,6 +18,9 @@ from tabs.functions_for_tab2.exporting import export_curve_txt
 from tabs.functions_for_tab2.segment_builder import build_segment
 from widgets import select_path
 from dataclasses import replace
+
+
+logger = logging.getLogger(__name__)
 
 
 class IntervalEditor(ttk.Frame):
@@ -547,8 +551,12 @@ class Tab2Frame(ttk.Frame):
         except ValidationError as exc:
             messagebox.showerror("Ошибка построения", str(exc))
             return
-        except Exception:  # noqa: BLE001
-            messagebox.showerror("Ошибка построения", "Внутренняя ошибка")
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Ошибка построения сегментов")
+            messagebox.showerror(
+                "Ошибка построения",
+                f"{exc}\nПроверьте параметры интервалов и повторите попытку.",
+            )
             return
 
         try:
@@ -560,8 +568,12 @@ class Tab2Frame(ttk.Frame):
         except ValidationError as exc:
             messagebox.showerror("Ошибка склейки", str(exc))
             return
-        except Exception:  # noqa: BLE001
-            messagebox.showerror("Ошибка склейки", "Внутренняя ошибка")
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Ошибка склейки сегментов")
+            messagebox.showerror(
+                "Ошибка склейки",
+                f"{exc}\nПроверьте параметры и попробуйте снова.",
+            )
             return
 
         plot_on_canvas(
@@ -606,8 +618,12 @@ class Tab2Frame(ttk.Frame):
         except ValidationError as exc:
             messagebox.showerror("Ошибка построения", str(exc))
             return
-        except Exception:  # noqa: BLE001
-            messagebox.showerror("Ошибка построения", "Внутренняя ошибка")
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Ошибка построения сегментов для экспорта")
+            messagebox.showerror(
+                "Ошибка построения",
+                f"{exc}\nПроверьте данные и повторите попытку.",
+            )
             return
 
         path = filedialog.asksaveasfilename(
@@ -623,8 +639,12 @@ class Tab2Frame(ttk.Frame):
             messagebox.showinfo("Успех", f"Кривая сохранена: {path}")
         except ValidationError as exc:
             messagebox.showerror("Ошибка экспорта", str(exc))
-        except Exception:  # noqa: BLE001
-            messagebox.showerror("Ошибка экспорта", "Внутренняя ошибка")
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Ошибка экспорта кривой")
+            messagebox.showerror(
+                "Ошибка экспорта",
+                f"{exc}\nПроверьте путь и повторите попытку.",
+            )
 
     def save_project(self) -> None:
         """Сохраняет текущую конфигурацию интервалов в JSON."""
@@ -644,7 +664,11 @@ class Tab2Frame(ttk.Frame):
                 json.dump(data, fh, ensure_ascii=False, indent=2)
             messagebox.showinfo("Успех", f"Проект сохранён: {path}")
         except Exception as exc:  # noqa: BLE001
-            messagebox.showerror("Ошибка сохранения", str(exc))
+            logger.exception("Ошибка сохранения проекта")
+            messagebox.showerror(
+                "Ошибка сохранения",
+                f"{exc}\nУбедитесь, что путь доступен и попробуйте снова.",
+            )
 
     def load_project(self) -> None:
         """Загружает конфигурацию интервалов из JSON."""
@@ -670,7 +694,11 @@ class Tab2Frame(ttk.Frame):
             self.redraw_plot()
             messagebox.showinfo("Успех", f"Проект загружен: {path}")
         except Exception as exc:  # noqa: BLE001
-            messagebox.showerror("Ошибка загрузки", str(exc))
+            logger.exception("Ошибка загрузки проекта")
+            messagebox.showerror(
+                "Ошибка загрузки",
+                f"{exc}\nПроверьте файл и повторите попытку.",
+            )
 
 
 def create_tab2(notebook: ttk.Notebook) -> ttk.Frame:


### PR DESCRIPTION
## Summary
- log full tracebacks and show helpful dialogs in tab1 graph builder
- log tracebacks and give recovery hints in tab2 actions

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8d2bc3ce8832abefc60cf3300b4d6