### PR TITLE
Обработка ошибок разметки подписей графика

### DIFF
--- a/tabs/tab1.py
+++ b/tabs/tab1.py
@@ -386,12 +386,14 @@ def create_tab1(notebook: ttk.Notebook) -> None:
                 )
                 editor_visible["shown"] = True
             logger.info("График построен успешно")
+        except ValueError as exc:
+            logger.error("Ошибка построения графика", exc_info=True)
+            messagebox.showerror("Ошибка", f"Не удалось построить график:\n{exc}")
         except Exception as exc:
             logger.exception("Ошибка при построении графика")
             messagebox.showerror(
                 "Ошибка",
-                f"Не удалось построить график:\n{exc}\n"
-                "Проверьте введённые данные и попробуйте снова.",
+                f"Не удалось построить график:\n{exc}\nПроверьте введённые данные и попробуйте снова.",
             )
 
     # Кнопка построения графика

--- a/tests/test_generate_graph_label_error.py
+++ b/tests/test_generate_graph_label_error.py
@@ -1,0 +1,59 @@
+import matplotlib.pyplot as plt
+import pytest
+
+from tabs.functions_for_tab1.plotting import generate_graph
+
+class Dummy:
+    def __init__(self, value=""):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+
+class DummyCanvas:
+    def draw(self):
+        pass
+
+
+class DummyFrame:
+    def winfo_children(self):
+        return []
+
+
+def test_generate_graph_invalid_label_markup():
+    fig, ax = plt.subplots()
+    canvas = DummyCanvas()
+    combo_title = Dummy("Нет")
+    entry_title_custom = Dummy("")
+    combo_titleX = Dummy("Другое")
+    combo_titleX_size = Dummy("")
+    entry_titleX = Dummy("$invalid")
+    combo_titleY = Dummy("Другое")
+    combo_titleY_size = Dummy("")
+    entry_titleY = Dummy("y")
+    legend_checkbox = Dummy(False)
+    curves_frame = DummyFrame()
+    combo_curves = Dummy("0")
+    combo_language = Dummy("Русский")
+
+    with pytest.raises(ValueError) as excinfo:
+        generate_graph(
+            ax,
+            fig,
+            canvas,
+            combo_title,
+            entry_title_custom,
+            combo_titleX,
+            combo_titleX_size,
+            entry_titleX,
+            combo_titleY,
+            combo_titleY_size,
+            entry_titleY,
+            legend_checkbox,
+            curves_frame,
+            combo_curves,
+            combo_language,
+        )
+    plt.close(fig)
+    assert "неправильной разметкой подписи" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- Логируем передаваемые подписи осей в `generate_graph`
- Показываем сообщение о некорректной разметке подписи при ошибке `MathTextParser`
- Добавлен тест проверки обработки неверной разметки

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8d3950b74832a8921a5ad4b4cfa63