### PR TITLE
Добавлена обёртка mathit жирным для заголовков

### DIFF
--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -1,6 +1,7 @@
 from tkinter import filedialog, messagebox
 from pathlib import Path
 import logging
+import re
 
 from tabs.function_for_all_tabs import create_plot
 from .curves_from_file import (
@@ -86,7 +87,7 @@ class TitleProcessor:
             title = self._get_title()
             result = f"{title}{self._get_units()}"
         if self.bold_math:
-            result = result.replace("\\mathit", "\\mathbf")
+            result = re.sub(r"\\mathit\{([^}]*)\}", r"\\mathbf{\\mathit{\1}}", result)
         return result
 
 def save_file(entry_widget, format_widget, graph_info):

--- a/tests/test_title_processor_bold_math.py
+++ b/tests/test_title_processor_bold_math.py
@@ -1,0 +1,30 @@
+from matplotlib.mathtext import MathTextParser
+
+from tabs.functions_for_tab1.plotting import TitleProcessor
+
+
+class ComboStub:
+    def __init__(self, value):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+
+def test_title_processor_wraps_mathit_with_bold():
+    combo_title = ComboStub("Время")
+    processor = TitleProcessor(combo_title, bold_math=True)
+    result = processor.get_processed_title()
+    assert "\\mathbf{\\mathit{t}}" in result
+    parser = MathTextParser("agg")
+    parser.parse(result)
+
+
+def test_title_processor_wraps_multiple_mathit_occurrences():
+    combo_title = ComboStub("Другое")
+    entry = ComboStub("Value $\\mathit{x}+\\mathit{y}$")
+    processor = TitleProcessor(combo_title, entry_title=entry, bold_math=True)
+    result = processor.get_processed_title()
+    assert result.count("\\mathbf{\\mathit{") == 2
+    parser = MathTextParser("agg")
+    parser.parse(result)


### PR DESCRIPTION
## Summary
- Реализована замена `\mathit{}` на `\mathbf{\mathit{}}` в `TitleProcessor`
- Добавлены тесты, проверяющие корректность `\mathbf{\mathit{}}`

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8df557a90832ab5d42949563e7ff6