### PR TITLE
Сделать жирный курсив для LaTeX-обозначений

### DIFF
--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -87,7 +87,7 @@ class TitleProcessor:
             title = self._get_title()
             result = f"{title}{self._get_units()}"
         if self.bold_math:
-            result = re.sub(r"\\mathit\{([^}]*)\}", r"\\mathbf{\\mathit{\1}}", result)
+            result = re.sub(r"\\mathit\{([^}]*)\}", r"\\boldsymbol{\\mathit{\1}}", result)
         return result
 
 def save_file(entry_widget, format_widget, graph_info):

--- a/tests/test_title_processor_bold_math.py
+++ b/tests/test_title_processor_bold_math.py
@@ -15,7 +15,7 @@ def test_title_processor_wraps_mathit_with_bold():
     combo_title = ComboStub("Время")
     processor = TitleProcessor(combo_title, bold_math=True)
     result = processor.get_processed_title()
-    assert "\\mathbf{\\mathit{t}}" in result
+    assert "\\boldsymbol{\\mathit{t}}" in result
     parser = MathTextParser("agg")
     parser.parse(result)
 
@@ -25,6 +25,6 @@ def test_title_processor_wraps_multiple_mathit_occurrences():
     entry = ComboStub("Value $\\mathit{x}+\\mathit{y}$")
     processor = TitleProcessor(combo_title, entry_title=entry, bold_math=True)
     result = processor.get_processed_title()
-    assert result.count("\\mathbf{\\mathit{") == 2
+    assert result.count("\\boldsymbol{\\mathit{") == 2
     parser = MathTextParser("agg")
     parser.parse(result)


### PR DESCRIPTION
## Summary
- Использовать `\boldsymbol` для выделения переменных в подписях
- Обновить тесты для проверки жирного курсивного форматирования

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8e26d93b4832aac4376ff62b8753f