### PR TITLE
feat: bold italic variables in plot titles

### DIFF
--- a/tests/test_format_plot_title_bfit.py
+++ b/tests/test_format_plot_title_bfit.py
@@ -1,0 +1,32 @@
+import matplotlib
+
+from tabs.function_for_all_tabs.plotting import format_plot_title_bfit
+
+
+def test_format_plot_title_bfit_mathtext():
+    prev = matplotlib.rcParams["text.usetex"]
+    matplotlib.rcParams["text.usetex"] = False
+    try:
+        assert format_plot_title_bfit("σ_x, МПа") == r"$\boldsymbol{\mathit{σ_x}}$, МПа"
+        assert format_plot_title_bfit("Time, s") == "Time, s"
+    finally:
+        matplotlib.rcParams["text.usetex"] = prev
+
+
+def test_format_plot_title_bfit_usetex():
+    prev = matplotlib.rcParams["text.usetex"]
+    matplotlib.rcParams["text.usetex"] = True
+    try:
+        assert format_plot_title_bfit("E, ГПа") == r"$\bm{\mathit{E}}$, ГПа"
+    finally:
+        matplotlib.rcParams["text.usetex"] = prev
+
+
+def test_format_plot_title_bfit_no_double_wrap():
+    prev = matplotlib.rcParams["text.usetex"]
+    matplotlib.rcParams["text.usetex"] = False
+    try:
+        s = r"$\boldsymbol{\mathit{t}}$"
+        assert format_plot_title_bfit(s) == s
+    finally:
+        matplotlib.rcParams["text.usetex"] = prev


### PR DESCRIPTION
## Summary
- add `format_plot_title_bfit` to convert variables in titles into bold italic for TeX and mathtext
- apply formatting when setting plot titles
- cover title formatting with tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8e77227a4832a9131d2df13cec3fa