### PR TITLE
Добавить bold italic шрифт для mathtext

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -8,6 +8,7 @@ def configure_matplotlib():
     plt.rcParams['mathtext.rm'] = 'Times New Roman'
     plt.rcParams['mathtext.it'] = 'Times New Roman:italic'
     plt.rcParams['mathtext.bf'] = 'Times New Roman:bold'
+    plt.rcParams['mathtext.bfit'] = 'Times New Roman:bold:italic'
     plt.rcParams['mathtext.sf'] = 'Times New Roman'
     plt.rcParams['mathtext.tt'] = 'Times New Roman'
     plt.rcParams['font.size'] = 14  # Общий размер шрифта


### PR DESCRIPTION
## Summary
- добавить параметр `mathtext.bfit` в конфигурацию `matplotlib`

## Testing
- `pytest` *(падает: ModuleNotFoundError: No module named 'tabs')*


------
https://chatgpt.com/codex/tasks/task_e_68a8ee5f858c832abcacd1dca32e6ffb