### PR TITLE
feat: add bold title translations

### DIFF
--- a/tabs/constants.py
+++ b/tabs/constants.py
@@ -2,6 +2,7 @@
 """Константы для вкладок приложения."""
 
 from collections.abc import Sequence
+import re
 
 
 def sort_options(
@@ -451,6 +452,12 @@ TITLE_TRANSLATIONS = {
     },
 }
 
+TITLE_TRANSLATIONS_BOLD = {
+    key: {lang: re.sub(r"\\mathit\{([^}]*)\}", r"\\boldsymbol{\\mathit{\1}}", text)
+          for lang, text in value.items()}
+    for key, value in TITLE_TRANSLATIONS.items()
+}
+
 __all__ = [
     "STRESS_UNITS",
     "UNITS_MAPPING",
@@ -462,4 +469,5 @@ __all__ = [
     "PHYSICAL_QUANTITIES_EN",
     "PHYSICAL_QUANTITIES_EN_TO_RU",
     "TITLE_TRANSLATIONS",
+    "TITLE_TRANSLATIONS_BOLD",
 ]

--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -13,6 +13,7 @@ from .curves_from_file import (
 )
 from tabs.constants import (
     TITLE_TRANSLATIONS,
+    TITLE_TRANSLATIONS_BOLD,
     PHYSICAL_QUANTITIES_EN_TO_RU,
     PHYSICAL_QUANTITIES_TRANSLATION,
     UNITS_MAPPING,
@@ -33,12 +34,14 @@ class TitleProcessor:
         entry_title=None,
         language="Русский",
         bold_math: bool = False,
+        translations=TITLE_TRANSLATIONS,
     ):
         self.combo_title = combo_title
         self.combo_size = combo_size
         self.entry_title = entry_title
         self.language = language
         self.bold_math = bold_math
+        self.translations = translations
 
     def _get_ru_en_quantity(self):
         selection = self.combo_title.get()
@@ -75,7 +78,9 @@ class TitleProcessor:
 
     def _get_title(self):
         ru, _ = self._get_ru_en_quantity()
-        return TITLE_TRANSLATIONS.get(ru, {}).get(self.language, self.combo_title.get())
+        return self.translations.get(ru, {}).get(
+            self.language, self.combo_title.get()
+        )
 
     def get_processed_title(self):
         selection = self.combo_title.get()
@@ -86,8 +91,10 @@ class TitleProcessor:
         else:
             title = self._get_title()
             result = f"{title}{self._get_units()}"
-        if self.bold_math:
-            result = re.sub(r"\\mathit\{([^}]*)\}", r"\\boldsymbol{\\mathit{\1}}", result)
+        if self.bold_math and "\\boldsymbol" not in result:
+            result = re.sub(
+                r"\\mathit\{([^}]*)\}", r"\\boldsymbol{\\mathit{\1}}", result
+            )
         return result
 
 def save_file(entry_widget, format_widget, graph_info):
@@ -156,7 +163,11 @@ def generate_graph(
     ax.clear()
     language = combo_language.get() or "Русский"
     title_processor = TitleProcessor(
-        combo_title, entry_title=entry_title_custom, language=language, bold_math=True
+        combo_title,
+        entry_title=entry_title_custom,
+        language=language,
+        bold_math=True,
+        translations=TITLE_TRANSLATIONS_BOLD,
     )
     xlabel_processor = TitleProcessor(
         combo_titleX, combo_titleX_size, entry_titleX, language

--- a/tests/test_title_processor_bold_math.py
+++ b/tests/test_title_processor_bold_math.py
@@ -1,6 +1,7 @@
 from matplotlib.mathtext import MathTextParser
 
 from tabs.functions_for_tab1.plotting import TitleProcessor
+from tabs.constants import TITLE_TRANSLATIONS_BOLD
 
 
 class ComboStub:
@@ -18,6 +19,16 @@ def test_title_processor_wraps_mathit_with_bold():
     assert "\\boldsymbol{\\mathit{t}}" in result
     parser = MathTextParser("agg")
     parser.parse(result)
+
+
+def test_title_processor_uses_bold_dict_only_for_title():
+    combo = ComboStub("Время")
+    title_proc = TitleProcessor(
+        combo, bold_math=True, translations=TITLE_TRANSLATIONS_BOLD
+    )
+    axis_proc = TitleProcessor(combo)
+    assert "\\boldsymbol{\\mathit{t}}" in title_proc.get_processed_title()
+    assert "\\boldsymbol{\\mathit{t}}" not in axis_proc.get_processed_title()
 
 
 def test_title_processor_wraps_multiple_mathit_occurrences():


### PR DESCRIPTION
## Summary
- add TITLE_TRANSLATIONS_BOLD dictionary for bold math symbols
- allow TitleProcessor to use custom translations and fallback bolding
- ensure graph titles use bold math while axis labels remain regular

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8f10602d8832a9480445b63a2da77