### PR TITLE
feat: separate title and axis translation dictionaries

### DIFF
--- a/tabs/constants.py
+++ b/tabs/constants.py
@@ -322,6 +322,7 @@ DEFAULT_UNITS_EN = {
     "Frequency 3": "Hz",
 }
 
+# Подписи осей с обычным курсивом
 TITLE_TRANSLATIONS = {
     "Время": {"Русский": r"Время $\mathit{t}$", "Английский": r"Time $\mathit{t}$"},
     "Перемещение по X": {
@@ -452,6 +453,7 @@ TITLE_TRANSLATIONS = {
     },
 }
 
+# Заголовки графиков — жирный курсив
 TITLE_TRANSLATIONS_BOLD = {
     key: {lang: re.sub(r"\\mathit\{([^}]*)\}", r"\\boldsymbol{\\mathit{\1}}", text)
           for lang, text in value.items()}

--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -34,13 +34,17 @@ class TitleProcessor:
         entry_title=None,
         language="Русский",
         bold_math: bool = False,
-        translations=TITLE_TRANSLATIONS,
+        translations=None,
     ):
         self.combo_title = combo_title
         self.combo_size = combo_size
         self.entry_title = entry_title
         self.language = language
         self.bold_math = bold_math
+        if translations is None:
+            translations = (
+                TITLE_TRANSLATIONS_BOLD if bold_math else TITLE_TRANSLATIONS
+            )
         self.translations = translations
 
     def _get_ru_en_quantity(self):
@@ -170,10 +174,18 @@ def generate_graph(
         translations=TITLE_TRANSLATIONS_BOLD,
     )
     xlabel_processor = TitleProcessor(
-        combo_titleX, combo_titleX_size, entry_titleX, language
+        combo_titleX,
+        combo_titleX_size,
+        entry_titleX,
+        language,
+        translations=TITLE_TRANSLATIONS,
     )
     ylabel_processor = TitleProcessor(
-        combo_titleY, combo_titleY_size, entry_titleY, language
+        combo_titleY,
+        combo_titleY_size,
+        entry_titleY,
+        language,
+        translations=TITLE_TRANSLATIONS,
     )
     title = title_processor.get_processed_title()
     xlabel = xlabel_processor.get_processed_title()

--- a/tests/test_title_processor_bold_math.py
+++ b/tests/test_title_processor_bold_math.py
@@ -1,7 +1,7 @@
 from matplotlib.mathtext import MathTextParser
 
 from tabs.functions_for_tab1.plotting import TitleProcessor
-from tabs.constants import TITLE_TRANSLATIONS_BOLD
+from tabs.constants import TITLE_TRANSLATIONS, TITLE_TRANSLATIONS_BOLD
 
 
 class ComboStub:
@@ -14,7 +14,9 @@ class ComboStub:
 
 def test_title_processor_wraps_mathit_with_bold():
     combo_title = ComboStub("Время")
-    processor = TitleProcessor(combo_title, bold_math=True)
+    processor = TitleProcessor(
+        combo_title, bold_math=True, translations=TITLE_TRANSLATIONS_BOLD
+    )
     result = processor.get_processed_title()
     assert "\\boldsymbol{\\mathit{t}}" in result
     parser = MathTextParser("agg")
@@ -26,7 +28,7 @@ def test_title_processor_uses_bold_dict_only_for_title():
     title_proc = TitleProcessor(
         combo, bold_math=True, translations=TITLE_TRANSLATIONS_BOLD
     )
-    axis_proc = TitleProcessor(combo)
+    axis_proc = TitleProcessor(combo, translations=TITLE_TRANSLATIONS)
     assert "\\boldsymbol{\\mathit{t}}" in title_proc.get_processed_title()
     assert "\\boldsymbol{\\mathit{t}}" not in axis_proc.get_processed_title()
 
@@ -34,7 +36,9 @@ def test_title_processor_uses_bold_dict_only_for_title():
 def test_title_processor_wraps_multiple_mathit_occurrences():
     combo_title = ComboStub("Другое")
     entry = ComboStub("Value $\\mathit{x}+\\mathit{y}$")
-    processor = TitleProcessor(combo_title, entry_title=entry, bold_math=True)
+    processor = TitleProcessor(
+        combo_title, entry_title=entry, bold_math=True, translations=TITLE_TRANSLATIONS_BOLD
+    )
     result = processor.get_processed_title()
     assert result.count("\\boldsymbol{\\mathit{") == 2
     parser = MathTextParser("agg")

--- a/tests/test_title_processor_translation.py
+++ b/tests/test_title_processor_translation.py
@@ -1,4 +1,5 @@
 from tabs.functions_for_tab1.plotting import TitleProcessor
+from tabs.constants import TITLE_TRANSLATIONS
 
 
 class ComboStub:
@@ -12,7 +13,12 @@ class ComboStub:
 def test_title_processor_translates_to_english():
     title_combo = ComboStub("Сила")
     size_combo = ComboStub("кН")
-    processor = TitleProcessor(title_combo, combo_size=size_combo, language="Английский")
+    processor = TitleProcessor(
+        title_combo,
+        combo_size=size_combo,
+        language="Английский",
+        translations=TITLE_TRANSLATIONS,
+    )
     result = processor.get_processed_title()
     assert "Force" in result
     assert ", kN" in result


### PR DESCRIPTION
## Summary
- clarify constants with separate title dictionaries
- let TitleProcessor choose translation set automatically
- ensure axis labels use italic dictionary and titles use bold

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8f1baac28832abae2da95a884ab54