### PR TITLE
Добавлен словарь символов заголовков

### DIFF
--- a/tabs/constants.py
+++ b/tabs/constants.py
@@ -453,6 +453,9 @@ TITLE_TRANSLATIONS = {
     },
 }
 
+# Символы для заголовков (копия словаря для осей)
+TITLES_SYMBOLS = {key: value.copy() for key, value in TITLE_TRANSLATIONS.items()}
+
 # Заголовки графиков — жирный курсив
 TITLE_TRANSLATIONS_BOLD = {
     key: {lang: re.sub(r"\\mathit\{([^}]*)\}", r"\\boldsymbol{\\mathit{\1}}", text)
@@ -470,6 +473,7 @@ __all__ = [
     "DEFAULT_UNITS_EN",
     "PHYSICAL_QUANTITIES_EN",
     "PHYSICAL_QUANTITIES_EN_TO_RU",
+    "TITLES_SYMBOLS",
     "TITLE_TRANSLATIONS",
     "TITLE_TRANSLATIONS_BOLD",
 ]

--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -12,8 +12,8 @@ from .curves_from_file import (
     read_X_Y_from_combined,
 )
 from tabs.constants import (
+    TITLES_SYMBOLS,
     TITLE_TRANSLATIONS,
-    TITLE_TRANSLATIONS_BOLD,
     PHYSICAL_QUANTITIES_EN_TO_RU,
     PHYSICAL_QUANTITIES_TRANSLATION,
     UNITS_MAPPING,
@@ -42,9 +42,7 @@ class TitleProcessor:
         self.language = language
         self.bold_math = bold_math
         if translations is None:
-            translations = (
-                TITLE_TRANSLATIONS_BOLD if bold_math else TITLE_TRANSLATIONS
-            )
+            translations = TITLES_SYMBOLS
         self.translations = translations
 
     def _get_ru_en_quantity(self):
@@ -171,7 +169,6 @@ def generate_graph(
         entry_title=entry_title_custom,
         language=language,
         bold_math=True,
-        translations=TITLE_TRANSLATIONS_BOLD,
     )
     xlabel_processor = TitleProcessor(
         combo_titleX,

--- a/tests/test_title_processor_bold_math.py
+++ b/tests/test_title_processor_bold_math.py
@@ -1,7 +1,7 @@
 from matplotlib.mathtext import MathTextParser
 
 from tabs.functions_for_tab1.plotting import TitleProcessor
-from tabs.constants import TITLE_TRANSLATIONS, TITLE_TRANSLATIONS_BOLD
+from tabs.constants import TITLE_TRANSLATIONS
 
 
 class ComboStub:
@@ -14,9 +14,7 @@ class ComboStub:
 
 def test_title_processor_wraps_mathit_with_bold():
     combo_title = ComboStub("Время")
-    processor = TitleProcessor(
-        combo_title, bold_math=True, translations=TITLE_TRANSLATIONS_BOLD
-    )
+    processor = TitleProcessor(combo_title, bold_math=True)
     result = processor.get_processed_title()
     assert "\\boldsymbol{\\mathit{t}}" in result
     parser = MathTextParser("agg")
@@ -25,9 +23,7 @@ def test_title_processor_wraps_mathit_with_bold():
 
 def test_title_processor_uses_bold_dict_only_for_title():
     combo = ComboStub("Время")
-    title_proc = TitleProcessor(
-        combo, bold_math=True, translations=TITLE_TRANSLATIONS_BOLD
-    )
+    title_proc = TitleProcessor(combo, bold_math=True)
     axis_proc = TitleProcessor(combo, translations=TITLE_TRANSLATIONS)
     assert "\\boldsymbol{\\mathit{t}}" in title_proc.get_processed_title()
     assert "\\boldsymbol{\\mathit{t}}" not in axis_proc.get_processed_title()
@@ -37,9 +33,10 @@ def test_title_processor_wraps_multiple_mathit_occurrences():
     combo_title = ComboStub("Другое")
     entry = ComboStub("Value $\\mathit{x}+\\mathit{y}$")
     processor = TitleProcessor(
-        combo_title, entry_title=entry, bold_math=True, translations=TITLE_TRANSLATIONS_BOLD
+        combo_title, entry_title=entry, bold_math=True
     )
     result = processor.get_processed_title()
     assert result.count("\\boldsymbol{\\mathit{") == 2
     parser = MathTextParser("agg")
     parser.parse(result)
+


### PR DESCRIPTION
## Summary
- Выделен новый словарь `TITLES_SYMBOLS` для символов заголовков
- `TitleProcessor` использует `TITLES_SYMBOLS` по умолчанию, оси продолжают брать данные из `TITLE_TRANSLATIONS`
- Обновлён импорт и логика формирования заголовков в `plotting.py`
- Исправлены тесты `TitleProcessor`

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9827d3ba4832ab2bbf33c9897e42c