### PR TITLE
Обработка математических обозначений с выделением жирным

### DIFF
--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -1,7 +1,6 @@
 from tkinter import filedialog, messagebox
 from pathlib import Path
 import logging
-import re
 
 from tabs.function_for_all_tabs import create_plot
 from .curves_from_file import (
@@ -19,6 +18,7 @@ from tabs.constants import (
     UNITS_MAPPING,
     UNITS_MAPPING_EN,
 )
+from tabs.title_utils import bold_math_symbols
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +82,6 @@ class TitleProcessor:
         ru, _ = self._get_ru_en_quantity()
         return self.translations.get(ru, {}).get(
             self.language, self.combo_title.get()
-        )
 
     def get_processed_title(self):
         selection = self.combo_title.get()
@@ -93,10 +92,8 @@ class TitleProcessor:
         else:
             title = self._get_title()
             result = f"{title}{self._get_units()}"
-        if self.bold_math and "\\boldsymbol" not in result:
-            result = re.sub(
-                r"\\mathit\{([^}]*)\}", r"\\boldsymbol{\\mathit{\1}}", result
-            )
+        if self.bold_math:
+            result = bold_math_symbols(result)
         return result
 
 def save_file(entry_widget, format_widget, graph_info):
@@ -116,7 +113,6 @@ def save_file(entry_widget, format_widget, graph_info):
                 ("All files", "*.*"),
             ],
             initialfile=f"{file_name}.{file_format}",
-        )
         if file_path:
             try:
                 fig.savefig(file_path, format=file_format)
@@ -169,21 +165,18 @@ def generate_graph(
         entry_title=entry_title_custom,
         language=language,
         bold_math=True,
-    )
     xlabel_processor = TitleProcessor(
         combo_titleX,
         combo_titleX_size,
         entry_titleX,
         language,
         translations=TITLE_TRANSLATIONS,
-    )
     ylabel_processor = TitleProcessor(
         combo_titleY,
         combo_titleY_size,
         entry_titleY,
         language,
         translations=TITLE_TRANSLATIONS,
-    )
     title = title_processor.get_processed_title()
     xlabel = xlabel_processor.get_processed_title()
     ylabel = ylabel_processor.get_processed_title()
@@ -232,27 +225,21 @@ def generate_graph(
                 if widget_name == f"curve_{i}_X_source":
                     curve_info.setdefault("X_source", {}).update(
                         {"source": widget.get()}
-                    )
                 elif widget_name == f"curve_{i}_Y_source":
                     curve_info.setdefault("Y_source", {}).update(
                         {"source": widget.get()}
-                    )
                 elif widget_name == f"curve_{i}_X_parameter":
                     curve_info.setdefault("X_source", {}).update(
                         {"parameter": widget.get()}
-                    )
                 elif widget_name == f"curve_{i}_Y_parameter":
                     curve_info.setdefault("Y_source", {}).update(
                         {"parameter": widget.get()}
-                    )
                 elif widget_name == f"curve_{i}_X_direction":
                     curve_info.setdefault("X_source", {}).update(
                         {"direction": widget.get()}
-                    )
                 elif widget_name == f"curve_{i}_Y_direction":
                     curve_info.setdefault("Y_source", {}).update(
                         {"direction": widget.get()}
-                    )
                 elif widget_name == f"curve_{i}_X_column":
                     value = widget.get()
                     column = 0 if value != "Y" else 1
@@ -264,11 +251,9 @@ def generate_graph(
                 elif widget_name == f"curve_{i}_X_range":
                     curve_info.setdefault("X_source", {}).update(
                         {"range_x": widget.get(), "use_ranges": True}
-                    )
                 elif widget_name == f"curve_{i}_Y_range":
                     curve_info.setdefault("Y_source", {}).update(
                         {"range_y": widget.get(), "use_ranges": True}
-                    )
 
                 # Получаем имя файла для каждой кривой
                 if widget_name == f"curve_{i}_filename":
@@ -277,19 +262,15 @@ def generate_graph(
                         if "X_source" in curve_info:
                             curve_info["X_source"].setdefault(
                                 "curve_file", widget.get()
-                            )
                         if "Y_source" in curve_info:
                             curve_info["Y_source"].setdefault(
                                 "curve_file", widget.get()
-                            )
                 elif widget_name == f"curve_{i}_filename_X":
                     curve_info.setdefault("X_source", {}).update(
                         {"curve_file": widget.get()}
-                    )
                 elif widget_name == f"curve_{i}_filename_Y":
                     curve_info.setdefault("Y_source", {}).update(
                         {"curve_file": widget.get()}
-                    )
 
                 if widget_name == f"curve_{i}_horizontal":
                     curve_info["horizontal"] = widget.var.get()
@@ -319,7 +300,6 @@ def generate_graph(
         if legend_checkbox.get() and not curve_info.get("curve_legend", "").strip():
             messagebox.showwarning(
                 "Предупреждение", f"Введите подпись легенды для кривой {i}"
-            )
             return
         # Проверяем источники и файлы данных для кривой
         if curve_info.get("curve_type") == "Комбинированный":
@@ -328,13 +308,11 @@ def generate_graph(
                 if not source_info.get("source"):
                     messagebox.showerror(
                         "Ошибка", f"Не указан источник {axis} для кривой {i}"
-                    )
                     return
                 file = source_info.get("curve_file")
                 if not file:
                     messagebox.showerror(
                         "Ошибка", f"Не указан файл данных для кривой {i}"
-                    )
                     return
                 if not Path(file).exists():
                     messagebox.showerror("Ошибка", f"Файл {file} не найден")
@@ -366,7 +344,6 @@ def generate_graph(
             fig=fig,
             ax=ax,
             legend=legend_checkbox.get(),
-        )
     except ValueError as exc:
         if exc.__cause__ is not None and isinstance(exc.__cause__, ValueError):
             logger.error("Ошибка разметки подписи", exc_info=True)
@@ -387,7 +364,6 @@ def generate_graph(
             "title": title,
             "fig": fig,
         }
-    )
 
     # Перерисовка графика
     canvas.draw()

--- a/tabs/title_utils.py
+++ b/tabs/title_utils.py
@@ -1,0 +1,44 @@
+import re
+
+
+def bold_math_symbols(text: str) -> str:
+    r"""Wrap math expressions ``\mathit{...}`` and ``M_x``, ``My``, ``Mz``
+    with ``$\\boldsymbol{...}$`` or ``$\\boldsymbol{\\mathit{...}}$``.
+
+    The function skips parts that are already bold (``\boldsymbol`` or
+    ``\mathbfit``) and respects existing math mode delimited by ``$``.
+    """
+
+    pattern = re.compile(r"\\mathit\{[^}]+\}|\bM(?:_?[xyz])\b")
+
+    def is_inside_math(s: str, pos: int) -> bool:
+        count = 0
+        escaped = False
+        for ch in s[:pos]:
+            if escaped:
+                escaped = False
+                continue
+            if ch == "\\":
+                escaped = True
+            elif ch == "$":
+                count += 1
+        return count % 2 == 1
+
+    def already_bold(s: str, start: int) -> bool:
+        prefix = s[:start]
+        return bool(
+            re.search(r"(\\boldsymbol|\\mathbfit)\s*\{\s*$", prefix)
+        )
+
+    def repl(match: re.Match) -> str:
+        s = match.string
+        start = match.start()
+        token = match.group(0)
+        if already_bold(s, start):
+            return token
+        wrapped = f"\\boldsymbol{{{token}}}"
+        if is_inside_math(s, start):
+            return wrapped
+        return f"${wrapped}$"
+
+    return pattern.sub(repl, text)

--- a/tests/test_title_processor_bold_math.py
+++ b/tests/test_title_processor_bold_math.py
@@ -40,3 +40,15 @@ def test_title_processor_wraps_multiple_mathit_occurrences():
     parser = MathTextParser("agg")
     parser.parse(result)
 
+
+def test_title_processor_wraps_M_symbols_and_preserves_math():
+    combo_title = ComboStub("Другое")
+    entry = ComboStub("M_x My $M_z$ $v$ \boldsymbol{My}")
+    processor = TitleProcessor(combo_title, entry_title=entry, bold_math=True)
+    result = processor.get_processed_title()
+    assert "\boldsymbol{M_x}" in result
+    assert result.count("\boldsymbol{My}") == 2
+    assert "$\boldsymbol{M_z}$" in result
+    assert "$v$" in result
+    parser = MathTextParser("agg")
+    parser.parse(result)


### PR DESCRIPTION
## Summary
- Добавлен модуль `title_utils` с функцией `bold_math_symbols` для оборачивания выражений вида `\mathit{...}` и `M_x/My/Mz` в `\boldsymbol`
- `TitleProcessor` теперь использует новую утилиту при включённом параметре `bold_math`
- Расширены тесты для проверки обработки обозначений `M_x`, `My`, `Mz`

## Testing
- `python3 -m pytest -q` *(не выполнено: отсутствует пакет pytest и доступ к репозиторию пакетов заблокирован)*

------
https://chatgpt.com/codex/tasks/task_e_68a983f52c10832a98202612dba8be74