### PR TITLE
Распознавание математических блоков в заголовках

### DIFF
--- a/tabs/title_utils.py
+++ b/tabs/title_utils.py
@@ -45,7 +45,31 @@ def bold_math_symbols(text: str) -> str:
 
 
 def format_title_bolditalic(text: str) -> str:
-    """Wrap the entire title in bold italic formatting."""
+    """Wrap text parts of a title in bold italic while preserving math.
+
+    The input string may contain segments enclosed in ``$`` which should
+    remain untouched. All other parts are considered plain text and are
+    wrapped with ``\textbf{\textit{...}}`` without adding extra ``$``
+    around the whole title.
+    """
+
     if not text:
         return text
-    return rf"$\\textit{{\\textbf{{{text}}}}}$"
+
+    # Split into math and non-math segments. The regex keeps the math
+    # delimiters so that the resulting list alternates between text and
+    # math parts.
+    segments = re.split(r"(\$[^$]*\$)", text)
+    formatted: list[str] = []
+
+    for segment in segments:
+        if not segment:
+            continue
+        if segment.startswith("$") and segment.endswith("$"):
+            # Math expression – keep as is.
+            formatted.append(segment)
+        else:
+            # Plain text – wrap with bold italic commands.
+            formatted.append(rf"\textbf{{\textit{{{segment}}}}}")
+
+    return "".join(formatted)

--- a/tests/test_title_formatting.py
+++ b/tests/test_title_formatting.py
@@ -8,7 +8,7 @@ from matplotlib.mathtext import MathTextParser
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
-from tabs.title_utils import bold_math_symbols
+from tabs.title_utils import bold_math_symbols, format_title_bolditalic
 
 parser = MathTextParser('agg')
 
@@ -57,3 +57,19 @@ def test_titles_bold_italic_math(title, xlabel, expected_tokens):
     assert r"\boldsymbol" not in ax.get_ylabel()
 
     plt.close(fig)
+
+
+def test_format_title_bolditalic_plain_text():
+    assert (
+        format_title_bolditalic("Заголовок")
+        == r"\textbf{\textit{Заголовок}}"
+    )
+
+
+def test_format_title_bolditalic_with_math():
+    result = format_title_bolditalic("Сумма $x+y$ равна")
+    assert result == r"\textbf{\textit{Сумма }}$x+y$\textbf{\textit{ равна}}"
+
+
+def test_format_title_bolditalic_only_math():
+    assert format_title_bolditalic("$a+b$") == "$a+b$"

--- a/tests/test_title_processor_bold_math.py
+++ b/tests/test_title_processor_bold_math.py
@@ -16,7 +16,7 @@ def test_title_processor_wraps_mathit_with_bold():
     combo_title = ComboStub("Время")
     processor = TitleProcessor(combo_title, bold_math=True)
     result = processor.get_processed_title()
-    assert "\\boldsymbol{\\mathit{t}}" in result
+    assert r"\boldsymbol{\mathit{t}}" in result
     parser = MathTextParser("agg")
     parser.parse(result)
 
@@ -25,30 +25,28 @@ def test_title_processor_uses_bold_dict_only_for_title():
     combo = ComboStub("Время")
     title_proc = TitleProcessor(combo, bold_math=True)
     axis_proc = TitleProcessor(combo, translations=TITLE_TRANSLATIONS)
-    assert "\\boldsymbol{\\mathit{t}}" in title_proc.get_processed_title()
-    assert "\\boldsymbol{\\mathit{t}}" not in axis_proc.get_processed_title()
+    assert r"\boldsymbol{\mathit{t}}" in title_proc.get_processed_title()
+    assert r"\boldsymbol{\mathit{t}}" not in axis_proc.get_processed_title()
 
 
 def test_title_processor_wraps_multiple_mathit_occurrences():
     combo_title = ComboStub("Другое")
     entry = ComboStub("Value $\\mathit{x}+\\mathit{y}$")
-    processor = TitleProcessor(
-        combo_title, entry_title=entry, bold_math=True
-    )
+    processor = TitleProcessor(combo_title, entry_title=entry, bold_math=True)
     result = processor.get_processed_title()
-    assert result.count("\\boldsymbol{\\mathit{") == 2
+    assert result.count(r"\boldsymbol{\mathit{") == 2
     parser = MathTextParser("agg")
     parser.parse(result)
 
 
 def test_title_processor_wraps_M_symbols_and_preserves_math():
     combo_title = ComboStub("Другое")
-    entry = ComboStub("M_x My $M_z$ $v$ \boldsymbol{My}")
+    entry = ComboStub("M_x My $M_z$ $v$ \\boldsymbol{My}")
     processor = TitleProcessor(combo_title, entry_title=entry, bold_math=True)
     result = processor.get_processed_title()
-    assert "\boldsymbol{M_x}" in result
-    assert result.count("\boldsymbol{My}") == 2
-    assert "$\boldsymbol{M_z}$" in result
+    assert r"\boldsymbol{M_x}" in result
+    assert result.count(r"\boldsymbol{My}") == 2
+    assert "$\\boldsymbol{M_z}$" in result
     assert "$v$" in result
     parser = MathTextParser("agg")
     parser.parse(result)


### PR DESCRIPTION
## Summary
- разделение заголовка на текст и математические сегменты при форматировании
- тесты для `format_title_bolditalic` и корректные ожидания в `test_title_processor_bold_math`

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a98d84a96c832a9b2f8bb6b8ab6a4e