### PR TITLE
Применить форматирование текста к заголовку и осям

### DIFF
--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -183,9 +183,12 @@ def generate_graph(
         translations=TITLE_TRANSLATIONS,
     )
     title = title_processor.get_processed_title()
-    title = format_title_bolditalic(title)
     xlabel = xlabel_processor.get_processed_title()
     ylabel = ylabel_processor.get_processed_title()
+
+    title = format_title_bolditalic(title)
+    xlabel = format_title_bolditalic(xlabel)
+    ylabel = format_title_bolditalic(ylabel)
 
     if combo_titleX.get() == "Другое" and (
         entry_titleX is None or not entry_titleX.get().strip()


### PR DESCRIPTION
## Summary
- применять format_title_bolditalic ко всем подписям графика

## Testing
- `pytest` *(падает: 21 ошибок при сборке тестов)*

------
https://chatgpt.com/codex/tasks/task_e_68a98f02b6f8832aac0941fbda8ef75b