### PR TITLE
Добавлен тест для форматирования заголовка с жирным курсивом

### DIFF
--- a/tests/test_format_title_bolditalic.py
+++ b/tests/test_format_title_bolditalic.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import sys
+
+import matplotlib
+matplotlib.use('Agg')
+from matplotlib.mathtext import MathTextParser
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from tabs.title_utils import bold_math_symbols, format_title_bolditalic
+
+
+def test_format_title_bolditalic_with_pre_bold_math():
+    text = r"Время $\boldsymbol{\mathit{t}}$"
+    processed = bold_math_symbols(text)
+    formatted = format_title_bolditalic(processed)
+    parser = MathTextParser('agg')
+    parser.parse(formatted)
+
+


### PR DESCRIPTION
## Summary
- add regression test ensuring format_title_bolditalic works with pre-formatted math

## Testing
- `pytest tests/test_format_title_bolditalic.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9907b4f20832a8b4d30a801376aae