### PR TITLE
Исправление форматирования подписей осей

### DIFF
--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -187,8 +187,9 @@ def generate_graph(
     ylabel = ylabel_processor.get_processed_title()
 
     title = format_title_bolditalic(title)
-    xlabel = format_title_bolditalic(xlabel)
-    ylabel = format_title_bolditalic(ylabel)
+    # xlabel and ylabel should remain without additional formatting
+    # xlabel = format_title_bolditalic(xlabel)
+    # ylabel = format_title_bolditalic(ylabel)
 
     if combo_titleX.get() == "Другое" and (
         entry_titleX is None or not entry_titleX.get().strip()


### PR DESCRIPTION
## Summary
- Отключено применение format_title_bolditalic к подписям осей

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a99286da3c832ab6bd81c6236c6d9c