### PR TITLE
Исправление подписи оси с частотой и тест MathText

### DIFF
--- a/tabs/functions_for_tab3/Figurenameclass.py
+++ b/tabs/functions_for_tab3/Figurenameclass.py
@@ -26,7 +26,7 @@ class FigureNames:
         elif any(self.name == f'{axis}mass' for axis in self.axes):
             return 'Масса, кг'
         elif any(self.name == f'{axis}eig' for axis in self.axes):
-            return 'Частота ${f}_{\mathit{1}}$, Гц'
+            return r'Частота $\mathit{f}_{\mathit{1}}$, Гц'
         elif any(self.name == f'{axis}N' for axis in self.axes):
             return 'Номер частоты'
         else:

--- a/tests/test_figure_names_ylabel_mathtext.py
+++ b/tests/test_figure_names_ylabel_mathtext.py
@@ -1,0 +1,14 @@
+from matplotlib.mathtext import MathTextParser
+import pytest
+
+from tabs.functions_for_tab3.Figurenameclass import FigureNames
+
+parser = MathTextParser("agg")
+
+@pytest.mark.parametrize("axis", ["X", "Y", "Z", "XR", "YR", "ZR"])
+def test_generate_plot_ylabel_mathtext_parsable(axis):
+    label = FigureNames(f"{axis}eig").generate_plot_ylabel()
+    try:
+        parser.parse(label)
+    except Exception as exc:  # pragma: no cover - explicit message on failure
+        pytest.fail(f"Ошибка парсинга подписи '{label}': {exc}")


### PR DESCRIPTION
## Summary
- Исправлена подпись оси частоты на италик `$\mathit{f}_{\mathit{1}}$`
- Добавлен тест, проверяющий корректный парсинг подписи оси через MathTextParser

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a993023038832aa123b4f712a2b2c1