### PR TITLE
Добавлен параметр для стиля заголовка графиков

### DIFF
--- a/tabs/function_for_all_tabs/plotting.py
+++ b/tabs/function_for_all_tabs/plotting.py
@@ -26,6 +26,7 @@ def create_plot(
     fig: Optional[Figure] = None,
     ax: Optional[Axes] = None,
     legend: Optional[bool] = None,
+    title_fontstyle: str = "normal",
     **kwargs: Any,
 ) -> None:
     """Create a plot based on provided curve data.
@@ -42,6 +43,7 @@ def create_plot(
         fig: Существующая фигура для построения графика.
         ax: Существующая ось для построения графика.
         legend: Отображать легенду при наличии ``ax``.
+        title_fontstyle: Стиль шрифта заголовка.
         **kwargs: Поддержка устаревших имен параметров для обратной совместимости.
     """
 
@@ -111,7 +113,7 @@ def create_plot(
             loc="left",
             fontsize=16,
             fontweight="bold",
-            fontstyle="italic",
+            fontstyle=title_fontstyle,
             fontname="Times New Roman",
         )
         plt.xlabel(
@@ -151,7 +153,7 @@ def create_plot(
             title,
             fontsize=16,
             fontweight="bold",
-            fontstyle="italic",
+            fontstyle=title_fontstyle,
             loc="left",
             fontname="Times New Roman",
         )

--- a/tests/test_create_plot_fontstyle.py
+++ b/tests/test_create_plot_fontstyle.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import sys
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from tabs.function_for_all_tabs import create_plot
+
+
+def test_default_title_fontstyle_normal():
+    fig, ax = plt.subplots()
+    curves = [{"X_values": [0, 1], "Y_values": [0, 1]}]
+    create_plot(curves, "X", "Y", "Title", fig=fig, ax=ax)
+    assert ax.title.get_fontstyle() == "normal"
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- Позволено задавать стиль шрифта заголовка графика через параметр `title_fontstyle`
- Добавлен тест, удостоверяющийся в нормальном стиле по умолчанию

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9952d1458832abf2a9ff48e4d19d8