### PR TITLE
Убрать LaTeX из заголовков и использовать свойства шрифта

### DIFF
--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -18,7 +18,7 @@ from tabs.constants import (
     UNITS_MAPPING,
     UNITS_MAPPING_EN,
 )
-from tabs.title_utils import bold_math_symbols, format_title_bolditalic
+from tabs.title_utils import bold_math_symbols
 
 logger = logging.getLogger(__name__)
 
@@ -186,10 +186,8 @@ def generate_graph(
     xlabel = xlabel_processor.get_processed_title()
     ylabel = ylabel_processor.get_processed_title()
 
-    title = format_title_bolditalic(title)
-    # xlabel and ylabel should remain without additional formatting
-    # xlabel = format_title_bolditalic(xlabel)
-    # ylabel = format_title_bolditalic(ylabel)
+    # Текст заголовка передается без LaTeX-команд,
+    # оформление выполняется через параметры Matplotlib.
 
     if combo_titleX.get() == "Другое" and (
         entry_titleX is None or not entry_titleX.get().strip()
@@ -369,6 +367,7 @@ def generate_graph(
             fig=fig,
             ax=ax,
             legend=legend_checkbox.get(),
+            title_fontstyle="italic",
         )
     except ValueError as exc:
         if exc.__cause__ is not None and isinstance(exc.__cause__, ValueError):

--- a/tabs/title_utils.py
+++ b/tabs/title_utils.py
@@ -45,31 +45,12 @@ def bold_math_symbols(text: str) -> str:
 
 
 def format_title_bolditalic(text: str) -> str:
-    """Wrap text parts of a title in bold italic while preserving math.
+    """Return ``text`` without LaTeX formatting.
 
-    The input string may contain segments enclosed in ``$`` which should
-    remain untouched. All other parts are considered plain text and are
-    wrapped with ``\textbf{\textit{...}}`` without adding extra ``$``
-    around the whole title.
+    Ранее функция оборачивала текст в ``\textbf{\textit{...}}``, что
+    приводило к наличию «сырых» LaTeX-команд в строке заголовка. Теперь
+    выделение делается средствами Matplotlib (параметры ``fontweight`` и
+    ``fontstyle``), поэтому функция просто возвращает исходную строку.
     """
 
-    if not text:
-        return text
-
-    # Split into math and non-math segments. The regex keeps the math
-    # delimiters so that the resulting list alternates between text and
-    # math parts.
-    segments = re.split(r"(\$[^$]*\$)", text)
-    formatted: list[str] = []
-
-    for segment in segments:
-        if not segment:
-            continue
-        if segment.startswith("$") and segment.endswith("$"):
-            # Math expression – keep as is.
-            formatted.append(segment)
-        else:
-            # Plain text – wrap with bold italic commands.
-            formatted.append(rf"\textbf{{\textit{{{segment}}}}}")
-
-    return "".join(formatted)
+    return text

--- a/tests/test_format_title_bolditalic.py
+++ b/tests/test_format_title_bolditalic.py
@@ -13,6 +13,7 @@ def test_format_title_bolditalic_with_pre_bold_math():
     text = r"Время $\boldsymbol{\mathit{t}}$"
     processed = bold_math_symbols(text)
     formatted = format_title_bolditalic(processed)
+    assert formatted == processed
     parser = MathTextParser('agg')
     parser.parse(formatted)
 

--- a/tests/test_title_formatting.py
+++ b/tests/test_title_formatting.py
@@ -60,15 +60,12 @@ def test_titles_bold_italic_math(title, xlabel, expected_tokens):
 
 
 def test_format_title_bolditalic_plain_text():
-    assert (
-        format_title_bolditalic("Заголовок")
-        == r"\textbf{\textit{Заголовок}}"
-    )
+    assert format_title_bolditalic("Заголовок") == "Заголовок"
 
 
 def test_format_title_bolditalic_with_math():
     result = format_title_bolditalic("Сумма $x+y$ равна")
-    assert result == r"\textbf{\textit{Сумма }}$x+y$\textbf{\textit{ равна}}"
+    assert result == "Сумма $x+y$ равна"
 
 
 def test_format_title_bolditalic_only_math():


### PR DESCRIPTION
## Summary
- format_title_bolditalic теперь просто возвращает исходный текст, а оформление делается средствами Matplotlib
- generate_graph передает заголовок без LaTeX и задаёт стиль шрифта через `title_fontstyle="italic"`
- тесты приведены в соответствие с новым поведением

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9961b82d4832a88ca1ab7b64cca8c