### PR TITLE
Добавлена функция форматирования обозначений

### DIFF
--- a/tabs/title_utils.py
+++ b/tabs/title_utils.py
@@ -1,6 +1,23 @@
 import re
 
 
+def format_designation(token: str, in_math: bool) -> str:
+    """Wrap ``token`` in ``\boldsymbol{}`` and add ``$`` if needed.
+
+    Parameters
+    ----------
+    token:
+        LaTeX token representing a designation (e.g. ``M_x`` or
+        ``\mathit{t}``).
+    in_math:
+        ``True`` if ``token`` already resides inside math mode, ``False``
+        otherwise.
+    """
+
+    wrapped = f"\\boldsymbol{{{token}}}"
+    return wrapped if in_math else f"${wrapped}$"
+
+
 def bold_math_symbols(text: str) -> str:
     r"""Wrap math expressions ``\mathit{...}`` and ``M_x``, ``My``, ``Mz``
     with ``$\\boldsymbol{...}$`` or ``$\\boldsymbol{\\mathit{...}}$``.
@@ -36,10 +53,7 @@ def bold_math_symbols(text: str) -> str:
         token = match.group(0)
         if already_bold(s, start):
             return token
-        wrapped = f"\\boldsymbol{{{token}}}"
-        if is_inside_math(s, start):
-            return wrapped
-        return f"${wrapped}$"
+        return format_designation(token, is_inside_math(s, start))
 
     return pattern.sub(repl, text)
 

--- a/tests/test_title_formatting.py
+++ b/tests/test_title_formatting.py
@@ -8,7 +8,11 @@ from matplotlib.mathtext import MathTextParser
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
-from tabs.title_utils import bold_math_symbols, format_title_bolditalic
+from tabs.title_utils import (
+    bold_math_symbols,
+    format_designation,
+    format_title_bolditalic,
+)
 
 parser = MathTextParser('agg')
 
@@ -57,6 +61,31 @@ def test_titles_bold_italic_math(title, xlabel, expected_tokens):
     assert r"\boldsymbol" not in ax.get_ylabel()
 
     plt.close(fig)
+
+
+@pytest.mark.parametrize(
+    "token,in_math,expected",
+    [
+        ("M_x", True, r"\boldsymbol{M_x}"),
+        ("M_x", False, r"$\boldsymbol{M_x}$"),
+        (r"\mathit{t}", True, r"\boldsymbol{\mathit{t}}"),
+        (r"\mathit{t}", False, r"$\boldsymbol{\mathit{t}}$"),
+    ],
+)
+def test_format_designation(token, in_math, expected):
+    assert format_designation(token, in_math) == expected
+
+
+def test_bold_math_symbols_uses_format_designation(monkeypatch):
+    calls = []
+
+    def fake(token, in_math):
+        calls.append((token, in_math))
+        return token
+
+    monkeypatch.setattr("tabs.title_utils.format_designation", fake)
+    bold_math_symbols("M_x")
+    assert calls == [("M_x", False)]
 
 
 def test_format_title_bolditalic_plain_text():


### PR DESCRIPTION
## Summary
- Добавлена функция `format_designation` для оборачивания обозначений в `\boldsymbol{}` с учётом нахождения в математическом режиме.
- `bold_math_symbols` теперь использует `format_designation` вместо локального кода.
- Добавлены тесты для новой функции и проверка использования `format_designation` внутри `bold_math_symbols`.

## Testing
- `pytest`
- `pytest tests/test_title_formatting.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9a0156744832a8ccc92d285ce2ed5