### PR TITLE
Добавлен режим TeX и тест конфигурации Matplotlib

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -3,17 +3,23 @@ import matplotlib.pyplot as plt
 
 def configure_matplotlib():
     """Configure global matplotlib settings used across the application."""
-    plt.rcParams['font.family'] = 'Times New Roman'
-    plt.rcParams['mathtext.fontset'] = 'custom'
-    plt.rcParams['mathtext.rm'] = 'Times New Roman'
-    plt.rcParams['mathtext.it'] = 'Times New Roman:italic'
-    plt.rcParams['mathtext.bf'] = 'Times New Roman:bold'
-    plt.rcParams['mathtext.bfit'] = 'Times New Roman:bold:italic'
-    plt.rcParams['mathtext.sf'] = 'Times New Roman'
-    plt.rcParams['mathtext.tt'] = 'Times New Roman'
-    plt.rcParams['font.size'] = 14  # Общий размер шрифта
-    plt.rcParams['axes.titlesize'] = 14  # Размер шрифта для заголовков осей
-    plt.rcParams['axes.labelsize'] = 14  # Размер шрифта для подписей осей
-    plt.rcParams['xtick.labelsize'] = 14  # Размер шрифта для меток оси X
-    plt.rcParams['ytick.labelsize'] = 14  # Размер шрифта для меток оси Y
-    plt.rcParams['legend.fontsize'] = 14  # Размер шрифта для легенды
+    plt.rcParams.update({
+        'text.usetex': True,
+        'font.family': 'serif',
+        'font.size': 14,  # Общий размер шрифта
+        'axes.titlesize': 14,  # Размер шрифта для заголовков осей
+        'axes.labelsize': 14,  # Размер шрифта для подписей осей
+        'xtick.labelsize': 14,  # Размер шрифта для меток оси X
+        'ytick.labelsize': 14,  # Размер шрифта для меток оси Y
+        'legend.fontsize': 14,  # Размер шрифта для легенды
+        'text.latex.preamble': (
+            r'\usepackage[utf8]{inputenc}\n'
+            r'\usepackage[T1]{fontenc}\n'
+            r'\usepackage[russian]{babel}\n'
+            r'\usepackage{tempora}\n'
+            r'\usepackage{newtxmath}\n'
+            r'\usepackage{amsmath}\n'
+            r'\usepackage{bm}\n'
+            r'\usepackage{upgreek}'
+        ),
+    })

--- a/tests/test_matplotlib_config.py
+++ b/tests/test_matplotlib_config.py
@@ -1,0 +1,21 @@
+import matplotlib.pyplot as plt
+from settings import configure_matplotlib
+
+
+def test_matplotlib_usetex_and_preamble():
+    plt.rcdefaults()
+    configure_matplotlib()
+    assert plt.rcParams['text.usetex'] is True
+    preamble = plt.rcParams['text.latex.preamble']
+    required_packages = [
+        '\\usepackage[utf8]{inputenc}',
+        '\\usepackage[T1]{fontenc}',
+        '\\usepackage[russian]{babel}',
+        '\\usepackage{tempora}',
+        '\\usepackage{newtxmath}',
+        '\\usepackage{amsmath}',
+        '\\usepackage{bm}',
+        '\\usepackage{upgreek}',
+    ]
+    for pkg in required_packages:
+        assert pkg in preamble


### PR DESCRIPTION
## Summary
- Включён режим TeX в глобальной конфигурации Matplotlib и указан преамбул для LaTeX
- Добавлен тест, проверяющий включение text.usetex и необходимые пакеты

## Testing
- `python -m pytest` *(falling tests: test_last_graph_save_file.py; ошибка сохранения файла, вероятно отсутствует LaTeX)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b2892928832a95ab89e0a3119374