### PR TITLE
Добавлен пример комбинированных подписей

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,15 @@ The axis dimension selectors support both SI units and engineering units based o
   `LS-DYNA` or `*KEYWORD`; if they are absent, the user is notified that
   the file is not a valid LS-DYNA curve.
 - Excel or CSV tables (first two columns are treated as X and Y).
+
+## Example: Combined Labels
+
+The script [`examples/combined_labels.py`](examples/combined_labels.py) demonstrates how to mix bold designations in the title with italic or upright symbols in axis labels.
+
+Run the example with:
+
+```bash
+python examples/combined_labels.py
+```
+
+You will get a plot where the title displays bold symbols such as $\boldsymbol{F_x}$ and $\boldsymbol{\upalpha}$, while the axis labels show `$\mathit{t}$` and `$\upalpha$` without bold formatting.

--- a/examples/combined_labels.py
+++ b/examples/combined_labels.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+# Ensure project root is on sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from tabs.title_utils import format_signature
+
+x = [0, 1, 2, 3]
+y = [0, 1, 4, 9]
+
+fig, ax = plt.subplots()
+ax.plot(x, y)
+
+ax.set_title(format_signature("Сила F_x при угле α", bold=True))
+ax.set_xlabel(format_signature("Время t, с", bold=False))
+ax.set_ylabel(format_signature("Угол α, рад", bold=False))
+
+plt.show()

--- a/tests/test_title_formatting.py
+++ b/tests/test_title_formatting.py
@@ -103,3 +103,20 @@ def test_format_title_bolditalic_with_math():
 
 def test_format_title_bolditalic_only_math():
     assert format_title_bolditalic("$a+b$") == "$a+b$"
+
+
+def test_axis_labels_combined_format():
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+    x_label = format_signature("Время t, с", bold=False)
+    y_label = format_signature("Угол α, рад", bold=False)
+    ax.set_xlabel(x_label)
+    ax.set_ylabel(y_label)
+
+    assert ax.get_xlabel() == "Время $\\mathit{t}$, с"
+    assert ax.get_ylabel() == "Угол $\\upalpha$, рад"
+    parser.parse(ax.get_xlabel())
+    assert "\\boldsymbol" not in ax.get_xlabel()
+    assert "\\boldsymbol" not in ax.get_ylabel()
+
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- добавлен пример использования жирных заголовков и обычных осевых подписей
- внесено описание примера в README
- добавлен тест комбинированных подписей

## Testing
- `PYTHONPATH=. pytest` *(падает: tests/test_last_graph_save_file.py::test_save_file_uses_updated_last_graph)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b3aa2c3c832aae4f8402bb80759d