### PR TITLE
Жирное оформление текстовых заголовков

### DIFF
--- a/tabs/title_utils.py
+++ b/tabs/title_utils.py
@@ -83,12 +83,13 @@ def format_signature(text: str, *, bold: bool) -> str:
 
     Латинские символы переводятся в ``\mathit{}``, а греческие заменяются
     командами ``\upalpha``, ``\upsigma`` и т.п. При ``bold=True`` найденные
-    обозначения дополнительно оборачиваются в ``\boldsymbol{...}``.
+    обозначения дополнительно оборачиваются в ``\boldsymbol{...}``, а
+    текстовые части — в ``\textbf{...}``.
 
     Примеры
     -------
     >>> format_signature('Момент M_x', bold=True)
-    'Момент $\boldsymbol{\mathit{M}_{\mathit{x}}}$'
+    '\\textbf{Момент }$\\boldsymbol{\\mathit{M}_{\\mathit{x}}}$'
     >>> format_signature('Угол α', bold=False)
     'Угол $\upalpha$'
 
@@ -129,7 +130,15 @@ def format_signature(text: str, *, bold: bool) -> str:
 
         return formatted if is_inside_math(match.string, match.start()) else f"${formatted}$"
 
-    return _TOKEN_PATTERN.sub(repl, text)
+    result = _TOKEN_PATTERN.sub(repl, text)
+    if bold:
+        parts = re.split(r"(\$[^$]*\$)", result)
+        result = "".join(
+            f"\\textbf{{{part}}}" if part and not part.startswith("$") else part
+            for part in parts
+            if part
+        )
+    return result
 
 
 def format_designation(token: str, in_math: bool) -> str:

--- a/tests/test_title_formatting.py
+++ b/tests/test_title_formatting.py
@@ -60,6 +60,8 @@ def test_titles_bold_italic_math(title, xlabel, expected_tokens):
     for token in expected_tokens:
         assert token in ax.get_title()
 
+    assert r"\textbf" in ax.get_title()
+
     assert ax.get_xlabel() == formatted_label
     assert ax.get_ylabel() == formatted_label
     assert r"\boldsymbol" not in formatted_label

--- a/tests/test_title_processor_bold_math.py
+++ b/tests/test_title_processor_bold_math.py
@@ -17,6 +17,7 @@ def test_title_processor_wraps_mathit_with_bold():
     processor = TitleProcessor(combo_title, bold_math=True)
     result = processor.get_processed_title()
     assert r"\boldsymbol{\mathit{t}}" in result
+    assert r"\textbf" in result
     parser = MathTextParser("agg")
     parser.parse(result)
 


### PR DESCRIPTION
## Summary
- Сделан форматер `format_signature` с поддержкой `\textbf{...}` для обычного текста
- Добавлены проверки на наличие `\textbf` в заголовках графиков

## Testing
- `PYTHONPATH=$PWD pytest tests/test_title_formatting.py tests/test_title_processor_bold_math.py -q`
- `pytest -q` *(ошибка: ModuleNotFoundError: No module named 'tabs')*


------
https://chatgpt.com/codex/tasks/task_e_68a9bdca170c832ab611c2eb80950de3