### PR TITLE
Добавлена функция split_signature для обработки подписей

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,33 +37,45 @@ This opens the GUI where you can create and customize plots across multiple tabs
 
 ## Форматирование подписей и обозначений
 
-Для заголовков графиков и подписей осей используйте функцию
-`format_signature` из модуля `tabs.title_utils`. Она переводит латинские
-буквы в курсив (`\mathit{}`), заменяет греческие символы на команды
-пакета `upgreek` и корректно обрабатывает индексы/степени. Параметр
-`bold=True` дополнительно оборачивает обозначения в `\boldsymbol{}`.
+Для заголовков графиков и подписей осей доступны две функции из модуля
+`tabs.title_utils`:
+
+- `format_signature` — возвращает строку целиком;
+- `split_signature` — разбивает исходный текст на сегменты вида
+  `(фрагмент, is_latex)`.
+
+Обе функции переводят латинские буквы в курсив (`\mathit{}`), заменяют
+греческие символы на команды пакета `upgreek` и корректно обрабатывают
+индексы/степени. Параметр `bold=True` дополнительно оборачивает
+обозначения в `\boldsymbol{}`.
 
 Примеры:
 
 - `format_signature('Момент M_x', bold=True)` → «Момент
   $\boldsymbol{\mathit{M}_{\mathit{x}}}$»
-- `format_signature('Угол α', bold=False)` → «Угол $\upalpha$»
-- `format_signature('Напряжение σ_{max}', bold=False)` → «Напряжение
-  $\upsigma_{\mathit{max}}$»
+- `split_signature('Угол α', bold=False)` → `[('Угол ', False),
+  ('\\upalpha', True)]`
+- `split_signature('Напряжение σ_{max}', bold=False)` →
+  `[('Напряжение ', False),
+  ('\\upsigma_{\\mathit{max}}', True)]`
 
 ### Пример использования с Matplotlib
 
 ```python
 import matplotlib.pyplot as plt
 from settings import configure_matplotlib
-from tabs.title_utils import format_signature
+from tabs.title_utils import split_signature
+
+
+def join_segments(parts):
+    return ''.join(f'${frag}$' if is_latex else frag for frag, is_latex in parts)
 
 configure_matplotlib()
 
 fig, ax = plt.subplots()
-ax.set_title(format_signature('Момент M_x', bold=True))
-ax.set_xlabel(format_signature('Угол α', bold=False))
-ax.set_ylabel(format_signature('Напряжение σ_{max}', bold=False))
+ax.set_title(join_segments(split_signature('Момент M_x', bold=True)))
+ax.set_xlabel(join_segments(split_signature('Угол α', bold=False)))
+ax.set_ylabel(join_segments(split_signature('Напряжение σ_{max}', bold=False)))
 plt.show()
 ```
 
@@ -80,7 +92,7 @@ The axis dimension selectors support both SI units and engineering units based o
 
 ## Example: Combined Labels
 
-The script [`examples/combined_labels.py`](examples/combined_labels.py) demonstrates how to mix bold designations in the title with italic or upright symbols in axis labels.
+The script [`examples/combined_labels.py`](examples/combined_labels.py) demonstrates how to use `split_signature` to mix bold designations in the title with italic or upright symbols in axis labels.
 
 Run the example with:
 

--- a/examples/combined_labels.py
+++ b/examples/combined_labels.py
@@ -5,7 +5,13 @@ import matplotlib.pyplot as plt
 
 # Ensure project root is on sys.path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from tabs.title_utils import format_signature
+from tabs.title_utils import split_signature
+
+
+def join_segments(parts):
+    """Объединить сегменты ``split_signature`` в строку."""
+
+    return "".join(f"${frag}$" if is_latex else frag for frag, is_latex in parts)
 
 x = [0, 1, 2, 3]
 y = [0, 1, 4, 9]
@@ -13,8 +19,8 @@ y = [0, 1, 4, 9]
 fig, ax = plt.subplots()
 ax.plot(x, y)
 
-ax.set_title(format_signature("Сила F_x при угле α", bold=True))
-ax.set_xlabel(format_signature("Время t, с", bold=False))
-ax.set_ylabel(format_signature("Угол α, рад", bold=False))
+ax.set_title(join_segments(split_signature("Сила F_x при угле α", bold=True)))
+ax.set_xlabel(join_segments(split_signature("Время t, с", bold=False)))
+ax.set_ylabel(join_segments(split_signature("Угол α, рад", bold=False)))
 
 plt.show()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))

--- a/tests/test_split_signature.py
+++ b/tests/test_split_signature.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from tabs.title_utils import split_signature, format_signature
+
+
+def join(parts):
+    return ''.join(f'${frag}$' if is_latex else frag for frag, is_latex in parts)
+
+
+def test_split_signature_basic():
+    parts = split_signature('Угол α', bold=False)
+    assert parts == [('Угол ', False), ('\\upalpha', True)]
+
+
+def test_split_signature_bold():
+    parts = split_signature('Момент M_x', bold=True)
+    assert parts == [
+        ('\\textbf{Момент }', False),
+        ('\\boldsymbol{\\mathit{M}_{\\mathit{x}}}', True),
+    ]
+
+
+def test_split_signature_roundtrip():
+    text = 'Сила F_x'
+    parts = split_signature(text, bold=True)
+    assert join(parts) == format_signature(text, bold=True)


### PR DESCRIPTION
## Summary
- Реализована функция `split_signature`, разбивающая подпись на сегменты и помечающая LaTeX-части
- `format_signature` теперь использует `split_signature` как обёртку
- Обновлены документация и пример `combined_labels`
- Добавлены тесты для `split_signature`

## Testing
- ❌ `pytest` (один тест не создал ожидаемый файл)

------
https://chatgpt.com/codex/tasks/task_e_68a9c568e31c832ab5e8cda55ead1a8d