### PR TITLE
Поддержка смешанных подписей

### DIFF
--- a/tabs/function_for_all_tabs/plotting.py
+++ b/tabs/function_for_all_tabs/plotting.py
@@ -1,8 +1,9 @@
 import logging
 import warnings
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
+import matplotlib as mpl
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from matplotlib.ticker import FuncFormatter
@@ -10,6 +11,7 @@ from matplotlib.mathtext import MathTextParser
 from settings import configure_matplotlib
 
 from mylibproject.myutils import to_percent
+from tabs.title_utils import split_signature
 
 
 logger = logging.getLogger(__name__)
@@ -17,9 +19,9 @@ logger = logging.getLogger(__name__)
 
 def create_plot(
     curves_info: List[Dict[str, List[float]]],
-    x_label: str,
-    y_label: str,
-    title: str,
+    x_label: List[Tuple[str, bool]],
+    y_label: List[Tuple[str, bool]],
+    title: List[Tuple[str, bool]],
     pr_y: bool = False,
     save_file: bool = False,
     file_plt: str = "",
@@ -34,9 +36,9 @@ def create_plot(
     Parameters:
         curves_info: Список словарей с данными кривых. Каждый словарь должен
             содержать ключи ``'X_values'`` и ``'Y_values'``.
-        x_label: Подпись оси X (отформатирована через ``format_signature``).
-        y_label: Подпись оси Y (отформатирована через ``format_signature``).
-        title: Заголовок графика (отформатирован через ``format_signature``).
+        x_label: Подпись оси X (список сегментов ``split_signature``).
+        y_label: Подпись оси Y (список сегментов ``split_signature``).
+        title: Заголовок графика (список сегментов ``split_signature``).
         pr_y: Если ``True``, значения Y отображаются в процентах.
         save_file: Флаг сохранения графика в файл.
         file_plt: Путь к файлу для сохранения графика.
@@ -48,6 +50,7 @@ def create_plot(
     """
 
     logger.info("Начало построения графика")
+    old_usetex = plt.rcParams.get("text.usetex", False)
     configure_matplotlib()
     if "prY" in kwargs:
         warnings.warn("prY is deprecated, use pr_y", DeprecationWarning, stacklevel=2)
@@ -64,74 +67,62 @@ def create_plot(
             "X_label is deprecated, use x_label", DeprecationWarning, stacklevel=2
         )
         logger.warning("Использован устаревший параметр X_label")
-        x_label = kwargs.pop("X_label")
+        x_label = split_signature(kwargs.pop("X_label"), bold=False)
     if "Y_label" in kwargs:
         warnings.warn(
             "Y_label is deprecated, use y_label", DeprecationWarning, stacklevel=2
         )
         logger.warning("Использован устаревший параметр Y_label")
-        y_label = kwargs.pop("Y_label")
+        y_label = split_signature(kwargs.pop("Y_label"), bold=False)
 
-    parser = MathTextParser("agg")
     try:
-        parser.parse(x_label)
-    except ValueError as exc:
-        message = f"Некорректная LaTeX-формула в подписи оси X: {x_label}"
-        logger.error(message)
-        raise ValueError(message) from exc
-    try:
-        parser.parse(y_label)
-    except ValueError as exc:
-        message = f"Некорректная LaTeX-формула в подписи оси Y: {y_label}"
-        logger.error(message)
-        raise ValueError(message) from exc
-    try:
-        parser.parse(title)
-    except ValueError as exc:
-        message = f"Некорректная LaTeX-формула в заголовке: {title}"
-        logger.error(message)
-        raise ValueError(message) from exc
+        parser = MathTextParser("agg")
+        for frag, is_latex in x_label:
+            if not is_latex:
+                continue
+            try:
+                parser.parse(frag)
+            except ValueError as exc:
+                message = f"Некорректная LaTeX-формула в подписи оси X: {frag}"
+                logger.error(message)
+                raise ValueError(message) from exc
+        for frag, is_latex in y_label:
+            if not is_latex:
+                continue
+            try:
+                parser.parse(frag)
+            except ValueError as exc:
+                message = f"Некорректная LaTeX-формула в подписи оси Y: {frag}"
+                logger.error(message)
+                raise ValueError(message) from exc
+        for frag, is_latex in title:
+            if not is_latex:
+                continue
+            try:
+                parser.parse(frag)
+            except ValueError as exc:
+                message = f"Некорректная LaTeX-формула в заголовке: {frag}"
+                logger.error(message)
+                raise ValueError(message) from exc
 
-    if fig is None:
-        logger.debug("Создание новой фигуры (pr_y=%s)", pr_y)
-        if pr_y:
-            fig = plt.figure(figsize=(8, 4.8))
-            formatter = FuncFormatter(to_percent)
-            plt.gca().yaxis.set_major_formatter(formatter)
-        else:
-            fig = plt.figure(figsize=(6.4, 4.8))
-    if ax is None:
-        for curve_info in curves_info:
-            plt.plot(
-                curve_info["X_values"],
-                curve_info["Y_values"],
-                marker=None,
-                linestyle="-",
-            )
-        plt.title(
-            title,
-            loc="left",
-            fontsize=16,
-            fontweight="bold",
-            fontstyle=title_fontstyle,
-            fontname="Times New Roman",
-        )
-        plt.xlabel(
-            x_label, fontname="Times New Roman", fontweight="normal"
-        )
-        plt.ylabel(
-            y_label, fontname="Times New Roman", fontweight="normal"
-        )
-        plt.grid(True)
-        fig.tight_layout()
-        fig.subplots_adjust(bottom=0.15)
-        if save_file:
-            logger.info("Сохранение графика в файл %s", file_plt)
-            fig.savefig(file_plt)
-        plt.close(fig)
-        logger.info("График построен и закрыт")
-    else:
-        logger.debug("Построение на существующей оси (legend=%s)", legend)
+        for frag, is_latex in (*x_label, *y_label, *title):
+            if not is_latex and "$" in frag:
+                message = f"Некорректная LaTeX-формула: {frag}"
+                logger.error(message)
+                raise ValueError(message) from ValueError(message)
+
+        created_fig = fig is None
+        if fig is None:
+            logger.debug("Создание новой фигуры (pr_y=%s)", pr_y)
+            if pr_y:
+                fig, ax = plt.subplots(figsize=(8, 4.8))
+                formatter = FuncFormatter(to_percent)
+                ax.yaxis.set_major_formatter(formatter)
+            else:
+                fig, ax = plt.subplots(figsize=(6.4, 4.8))
+        if ax is None:
+            ax = fig.gca()
+
         if legend:
             for curve_info in curves_info:
                 ax.plot(
@@ -139,7 +130,7 @@ def create_plot(
                     curve_info["Y_values"],
                     marker=None,
                     linestyle="-",
-                    label=curve_info["curve_legend"],
+                    label=curve_info.get("curve_legend"),
                 )
         else:
             for curve_info in curves_info:
@@ -149,24 +140,111 @@ def create_plot(
                     marker=None,
                     linestyle="-",
                 )
-        ax.set_title(
+
+        fig.canvas.draw()
+
+        def _render_segments(
+            segments: List[Tuple[str, bool]],
+            *,
+            x: float,
+            y: float,
+            vertical: bool = False,
+            rotation: float = 0.0,
+            **text_kwargs: Any,
+        ) -> None:
+            trans = ax.transAxes
+            renderer = fig.canvas.get_renderer()
+            for frag, is_latex in segments:
+                if is_latex:
+                    txt = ax.text(
+                        x,
+                        y,
+                        f"${frag}$",
+                        transform=trans,
+                        usetex=True,
+                        rotation=rotation,
+                        **text_kwargs,
+                    )
+                    try:
+                        bbox = txt.get_window_extent(renderer=renderer)
+                    except RuntimeError:
+                        txt.remove()
+                        txt = ax.text(
+                            x,
+                            y,
+                            f"${frag}$",
+                            transform=trans,
+                            usetex=False,
+                            rotation=rotation,
+                            **text_kwargs,
+                        )
+                        bbox = txt.get_window_extent(renderer=renderer)
+                else:
+                    with mpl.rc_context(
+                        {"text.usetex": False, "font.family": "Times New Roman"}
+                    ):
+                        txt = ax.text(
+                            x,
+                            y,
+                            frag,
+                            transform=trans,
+                            rotation=rotation,
+                            **text_kwargs,
+                        )
+                        bbox = txt.get_window_extent(renderer=renderer)
+                if vertical:
+                    dy = (
+                        ax.transAxes.inverted().transform((0, bbox.height))[1]
+                        - ax.transAxes.inverted().transform((0, 0))[1]
+                    )
+                    y -= dy
+                else:
+                    dx = (
+                        ax.transAxes.inverted().transform((bbox.width, 0))[0]
+                        - ax.transAxes.inverted().transform((0, 0))[0]
+                    )
+                    x += dx
+
+        _render_segments(
             title,
-            fontsize=16,
+            x=0.0,
+            y=1.02,
             fontweight="bold",
             fontstyle=title_fontstyle,
-            loc="left",
-            fontname="Times New Roman",
+            fontsize=16,
         )
-        ax.set_xlabel(
-            x_label, fontname="Times New Roman", fontweight="normal"
+        _render_segments(
+            x_label,
+            x=0.0,
+            y=-0.1,
+            fontweight="normal",
+            fontstyle="normal",
+            fontsize=12,
         )
-        ax.set_ylabel(
-            y_label, fontname="Times New Roman", fontweight="normal"
+        _render_segments(
+            y_label,
+            x=-0.1,
+            y=1.0,
+            vertical=True,
+            rotation=90,
+            fontweight="normal",
+            fontstyle="normal",
+            fontsize=12,
         )
+
         ax.grid(True)
         fig.tight_layout()
         fig.subplots_adjust(bottom=0.15)
         if legend:
             logger.debug("Добавление легенды")
             ax.legend()
-        logger.info("График построен")
+        if save_file:
+            logger.info("Сохранение графика в файл %s", file_plt)
+            fig.savefig(file_plt)
+        if created_fig:
+            plt.close(fig)
+            logger.info("График построен и закрыт")
+        else:
+            logger.info("График построен")
+    finally:
+        plt.rcParams["text.usetex"] = old_usetex

--- a/tabs/function_for_all_tabs/plotting_adapter.py
+++ b/tabs/function_for_all_tabs/plotting_adapter.py
@@ -7,7 +7,7 @@ from matplotlib.figure import Figure
 from matplotlib.axes import Axes
 
 from tabs.function_for_all_tabs import create_plot
-from tabs.title_utils import format_signature
+from tabs.title_utils import split_signature
 
 Curve = Dict[str, List[float]]
 
@@ -34,14 +34,14 @@ def plot_on_canvas(
 ) -> None:
     """Clear ``ax`` and render ``curves`` using shared style utilities."""
     ax.clear()
-    title_fmt = format_signature(title, bold=True)
-    x_fmt = format_signature(x_label, bold=False)
-    y_fmt = format_signature(y_label, bold=False)
+    title_seg = split_signature(title, bold=True)
+    x_seg = split_signature(x_label, bold=False)
+    y_seg = split_signature(y_label, bold=False)
     create_plot(
         curves,
-        x_fmt,
-        y_fmt,
-        title_fmt,
+        x_seg,
+        y_seg,
+        title_seg,
         pr_y=pr_y,
         fig=fig,
         ax=ax,

--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -18,7 +18,7 @@ from tabs.constants import (
     UNITS_MAPPING,
     UNITS_MAPPING_EN,
 )
-from tabs.title_utils import format_signature
+from tabs.title_utils import split_signature
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +93,7 @@ class TitleProcessor:
         else:
             title = self._get_title()
             result = f"{title}{self._get_units()}"
-        return format_signature(result, bold=self.bold_math)
+        return split_signature(result, bold=self.bold_math)
 
 def save_file(entry_widget, format_widget, graph_info):
 

--- a/tabs/functions_for_tab3/plotting.py
+++ b/tabs/functions_for_tab3/plotting.py
@@ -3,6 +3,7 @@ from tabs.functions_for_tab3.Figurenameclass import FigureNames
 from widgets.message_log import message_log
 
 from tabs.function_for_all_tabs import create_plot
+from tabs.title_utils import split_signature
 
 
 def create_png_plots(graph_with_time, file_path_outeig, log_text):
@@ -10,7 +11,7 @@ def create_png_plots(graph_with_time, file_path_outeig, log_text):
 
     for name, graph in graph_with_time.items():
         X_values = [float(item[0]) for item in graph]
-        xlabel = "Время $t$, с"
+        xlabel = split_signature("Время t, с", bold=False)
         namefig = FigureNames(name)
 
         keys = ["XR", "YR", "ZR", "X", "Y", "Z"]
@@ -30,8 +31,8 @@ def create_png_plots(graph_with_time, file_path_outeig, log_text):
             create_plot(
                 curves_info,
                 xlabel,
-                namefig.generate_plot_ylabel(),
-                namefig.generate_plot_title(),
+                split_signature(namefig.generate_plot_ylabel(), bold=False),
+                split_signature(namefig.generate_plot_title(), bold=True),
                 pr_y=True,
                 save_file=True,
                 file_plt=file_plt,
@@ -42,8 +43,8 @@ def create_png_plots(graph_with_time, file_path_outeig, log_text):
             create_plot(
                 curves_info,
                 xlabel,
-                namefig.generate_plot_ylabel(),
-                namefig.generate_plot_title(),
+                split_signature(namefig.generate_plot_ylabel(), bold=False),
+                split_signature(namefig.generate_plot_title(), bold=True),
                 pr_y=False,
                 save_file=True,
                 file_plt=file_plt,

--- a/tests/test_create_plot_fontstyle.py
+++ b/tests/test_create_plot_fontstyle.py
@@ -7,11 +7,19 @@ import matplotlib.pyplot as plt
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 from tabs.function_for_all_tabs import create_plot
+from tabs.title_utils import split_signature
 
 
 def test_default_title_fontstyle_normal():
     fig, ax = plt.subplots()
     curves = [{"X_values": [0, 1], "Y_values": [0, 1]}]
-    create_plot(curves, "X", "Y", "Title", fig=fig, ax=ax)
-    assert ax.title.get_fontstyle() == "normal"
+    create_plot(
+        curves,
+        split_signature("X", bold=False),
+        split_signature("Y", bold=False),
+        split_signature("Title", bold=True),
+        fig=fig,
+        ax=ax,
+    )
+    assert ax.texts[0].get_fontstyle() == "normal"
     plt.close(fig)

--- a/tests/test_title_processor_bold_math.py
+++ b/tests/test_title_processor_bold_math.py
@@ -16,18 +16,29 @@ def test_title_processor_wraps_mathit_with_bold():
     combo_title = ComboStub("Время")
     processor = TitleProcessor(combo_title, bold_math=True)
     result = processor.get_processed_title()
-    assert r"\boldsymbol{\mathit{t}}" in result
-    assert r"\textbf" in result
+    joined = "".join(
+        f"${frag}$" if is_latex else frag for frag, is_latex in result
+    )
+    assert r"\boldsymbol{\mathit{t}}" in joined
+    assert r"\textbf" in joined
     parser = MathTextParser("agg")
-    parser.parse(result)
+    parser.parse(joined)
 
 
 def test_title_processor_uses_bold_dict_only_for_title():
     combo = ComboStub("Время")
     title_proc = TitleProcessor(combo, bold_math=True)
     axis_proc = TitleProcessor(combo, translations=TITLE_TRANSLATIONS)
-    assert r"\boldsymbol{\mathit{t}}" in title_proc.get_processed_title()
-    assert r"\boldsymbol{\mathit{t}}" not in axis_proc.get_processed_title()
+    joined_title = "".join(
+        f"${frag}$" if is_latex else frag
+        for frag, is_latex in title_proc.get_processed_title()
+    )
+    joined_axis = "".join(
+        f"${frag}$" if is_latex else frag
+        for frag, is_latex in axis_proc.get_processed_title()
+    )
+    assert r"\boldsymbol{\mathit{t}}" in joined_title
+    assert r"\boldsymbol{\mathit{t}}" not in joined_axis
 
 
 def test_title_processor_wraps_multiple_mathit_occurrences():
@@ -35,9 +46,12 @@ def test_title_processor_wraps_multiple_mathit_occurrences():
     entry = ComboStub("Value $\\mathit{x}+\\mathit{y}$")
     processor = TitleProcessor(combo_title, entry_title=entry, bold_math=True)
     result = processor.get_processed_title()
-    assert result.count(r"\boldsymbol{\mathit{") == 2
+    joined = "".join(
+        f"${frag}$" if is_latex else frag for frag, is_latex in result
+    )
+    assert joined.count(r"\boldsymbol{\mathit{") == 2
     parser = MathTextParser("agg")
-    parser.parse(result)
+    parser.parse(joined)
 
 
 def test_title_processor_wraps_M_symbols_and_preserves_math():
@@ -45,10 +59,13 @@ def test_title_processor_wraps_M_symbols_and_preserves_math():
     entry = ComboStub("M_x My $M_z$ $v$ \\boldsymbol{My}")
     processor = TitleProcessor(combo_title, entry_title=entry, bold_math=True)
     result = processor.get_processed_title()
-    assert r"\boldsymbol{\mathit{M}_{\mathit{x}}}" in result
-    assert result.count(r"\boldsymbol{My}") == 1
-    assert " My " in result
-    assert "$\\boldsymbol{\mathit{M}_{\mathit{z}}}$" in result
-    assert "$\\boldsymbol{\mathit{v}}$" in result
+    joined = "".join(
+        f"${frag}$" if is_latex else frag for frag, is_latex in result
+    )
+    assert r"\boldsymbol{\mathit{M}_{\mathit{x}}}" in joined
+    assert joined.count(r"\boldsymbol{My}") == 1
+    assert " My " in joined
+    assert "$\\boldsymbol{\mathit{M}_{\mathit{z}}}$" in joined
+    assert "$\\boldsymbol{\mathit{v}}$" in joined
     parser = MathTextParser("agg")
-    parser.parse(result)
+    parser.parse(joined)

--- a/tests/test_title_processor_translation.py
+++ b/tests/test_title_processor_translation.py
@@ -20,5 +20,8 @@ def test_title_processor_translates_to_english():
         translations=TITLE_TRANSLATIONS,
     )
     result = processor.get_processed_title()
-    assert "Force" in result
-    assert ", kN" in result
+    joined = "".join(
+        f"${frag}$" if is_latex else frag for frag, is_latex in result
+    )
+    assert "Force" in joined
+    assert ", kN" in joined


### PR DESCRIPTION
## Summary
- обновлён `create_plot` для приёма сегментов `split_signature` и отрисовки LaTeX/обычного текста
- `TitleProcessor` теперь возвращает сегменты вместо строк
- исправлены и дополнены тесты

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9c72ac3f0832aa7e7c548123f2ed6