### PR TITLE
Перенос тестов на split_signature и интеграционная проверка рендеринга

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ This opens the GUI where you can create and customize plots across multiple tabs
 Для заголовков графиков и подписей осей доступны две функции из модуля
 `tabs.title_utils`:
 
-- `format_signature` — возвращает строку целиком;
 - `split_signature` — разбивает исходный текст на сегменты вида
-  `(фрагмент, is_latex)`.
+  `(фрагмент, is_latex)`;
+- `format_signature` — обёртка, объединяющая сегменты в строку для
+  обратной совместимости.
 
 Обе функции переводят латинские буквы в курсив (`\mathit{}`), заменяют
 греческие символы на команды пакета `upgreek` и корректно обрабатывают
@@ -51,7 +52,7 @@ This opens the GUI where you can create and customize plots across multiple tabs
 
 Примеры:
 
-- `format_signature('Момент M_x', bold=True)` → «Момент
+- `join_segments(split_signature('Момент M_x', bold=True))` → «Момент
   $\boldsymbol{\mathit{M}_{\mathit{x}}}$»
 - `split_signature('Угол α', bold=False)` → `[('Угол ', False),
   ('\\upalpha', True)]`

--- a/examples/combined_labels.py
+++ b/examples/combined_labels.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 
+# Пример демонстрирует использование нового API ``split_signature``,
+# возвращающего список сегментов для последующей отрисовки.
 # Ensure project root is on sys.path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from tabs.title_utils import split_signature

--- a/tests/test_format_signature.py
+++ b/tests/test_format_signature.py
@@ -7,7 +7,11 @@ from matplotlib.mathtext import MathTextParser
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
-from tabs.title_utils import format_signature
+from tabs.title_utils import split_signature
+
+
+def join_segments(parts):
+    return "".join(f"${frag}$" if is_latex else frag for frag, is_latex in parts)
 
 parser = MathTextParser('agg')
 
@@ -20,19 +24,19 @@ def _parse_or_fail(text: str) -> None:
 
 
 def test_latin_italic():
-    result = format_signature('Момент M_x', bold=False)
+    parts = split_signature('Момент M_x', bold=False)
+    result = join_segments(parts)
     _parse_or_fail(result)
-    assert '\\mathit{M}' in result
-    assert '_{\\mathit{x}}' in result
+    assert parts == [('Момент ', False), ('\\mathit{M}_{\\mathit{x}}', True)]
 
 
 def test_greek_upright():
-    result = format_signature('Угол α', bold=False)
-    assert '\\upalpha' in result
-    assert '\\mathit' not in result
+    parts = split_signature('Угол α', bold=False)
+    assert parts == [('Угол ', False), ('\\upalpha', True)]
 
 
 def test_bold_true():
-    result = format_signature('Сила F_x', bold=True)
+    parts = split_signature('Сила F_x', bold=True)
+    result = join_segments(parts)
     _parse_or_fail(result)
-    assert '\\boldsymbol' in result
+    assert ('\\boldsymbol{\\mathit{F}_{\\mathit{x}}}', True) in parts

--- a/tests/test_segment_rendering.py
+++ b/tests/test_segment_rendering.py
@@ -1,0 +1,32 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from matplotlib.transforms import Bbox
+from unittest.mock import patch
+
+from tabs.function_for_all_tabs.plotting import create_plot
+from tabs.title_utils import split_signature
+
+
+def test_segments_usetex_and_font():
+    fig, ax = plt.subplots()
+    curves = [{"X_values": [0, 1], "Y_values": [0, 1]}]
+    title = split_signature("Title M_x", bold=False)
+    with patch(
+        "matplotlib.text.Text.get_window_extent",
+        return_value=Bbox.from_bounds(0, 0, 1, 1),
+    ):
+        create_plot(
+            curves,
+            split_signature("X", bold=False),
+            split_signature("Y", bold=False),
+            title,
+            fig=fig,
+            ax=ax,
+        )
+    plain = next(t for t in ax.texts if t.get_text() == "Title ")
+    latex = next(t for t in ax.texts if t.get_text() == "$\\mathit{M}_{\\mathit{x}}$")
+    assert not plain.get_usetex()
+    assert "Times New Roman" in plain.get_fontfamily()
+    assert latex.get_usetex()
+    plt.close(fig)

--- a/tests/test_title_formatting.py
+++ b/tests/test_title_formatting.py
@@ -11,9 +11,13 @@ sys.path.append(str(Path(__file__).resolve().parent.parent))
 from tabs.title_utils import (
     bold_math_symbols,
     format_designation,
-    format_signature,
     format_title_bolditalic,
+    split_signature,
 )
+
+
+def join_segments(parts):
+    return "".join(f"${frag}$" if is_latex else frag for frag, is_latex in parts)
 
 parser = MathTextParser('agg')
 
@@ -47,8 +51,8 @@ parser = MathTextParser('agg')
 def test_titles_bold_italic_math(title, xlabel, expected_tokens):
     fig, ax = plt.subplots()
     ax.plot([0, 1], [0, 1])
-    formatted_title = format_signature(title, bold=True)
-    formatted_label = format_signature(xlabel, bold=False)
+    formatted_title = join_segments(split_signature(title, bold=True))
+    formatted_label = join_segments(split_signature(xlabel, bold=False))
     ax.set_title(formatted_title)
     ax.set_xlabel(formatted_label)
     ax.set_ylabel(formatted_label)
@@ -79,8 +83,8 @@ def test_titles_bold_italic_math(title, xlabel, expected_tokens):
 def test_greek_letters_with_latin_indices(token, expected_title, expected_label):
     fig, ax = plt.subplots()
     ax.plot([0, 1], [0, 1])
-    formatted_title = format_signature(f"Параметр {token}", bold=True)
-    formatted_label = format_signature(token, bold=False)
+    formatted_title = join_segments(split_signature(f"Параметр {token}", bold=True))
+    formatted_label = join_segments(split_signature(token, bold=False))
     ax.set_title(formatted_title)
     ax.set_xlabel(formatted_label)
     ax.set_ylabel(formatted_label)
@@ -106,8 +110,8 @@ def test_greek_letters_with_latin_indices(token, expected_title, expected_label)
         ("λ_i^j", False, r"\uplambda_{\mathit{i}}^{\mathit{j}}"),
     ],
 )
-def test_format_signature_with_super_and_sub(token, bold, expected):
-    formatted = format_signature(token, bold=bold)
+def test_split_signature_with_super_and_sub(token, bold, expected):
+    formatted = join_segments(split_signature(token, bold=bold))
     sanitized = formatted.replace("\\upsigma", "\\sigma").replace("\\uplambda", "\\lambda")
     parser.parse(sanitized)
     assert formatted == f"${expected}$"
@@ -154,8 +158,8 @@ def test_format_title_bolditalic_only_math():
 def test_axis_labels_combined_format():
     fig, ax = plt.subplots()
     ax.plot([0, 1], [0, 1])
-    x_label = format_signature("Время t, с", bold=False)
-    y_label = format_signature("Угол α, рад", bold=False)
+    x_label = join_segments(split_signature("Время t, с", bold=False))
+    y_label = join_segments(split_signature("Угол α, рад", bold=False))
     ax.set_xlabel(x_label)
     ax.set_ylabel(y_label)
 


### PR DESCRIPTION
## Summary
- Переписаны юнит-тесты под API `split_signature`
- Добавлены интеграционные тесты на отрисовку сегментов с LaTeX и обычным шрифтом
- Обновлены README и пример `combined_labels.py`

## Testing
- `pytest tests/test_format_signature.py tests/test_title_formatting.py tests/test_create_plot_fontstyle.py tests/test_generate_graph_title_fontstyle.py tests/test_split_signature.py tests/test_segment_rendering.py`

------
https://chatgpt.com/codex/tasks/task_e_68a9d0662a44832a848da7d6800c8ee7