### PR TITLE
Исключено использование \textbf в заголовках

### DIFF
--- a/tabs/title_utils.py
+++ b/tabs/title_utils.py
@@ -113,13 +113,6 @@ def _format_signature_impl(text: str, bold: bool) -> str:
         return formatted if is_inside_math(match.string, match.start()) else f"${formatted}$"
 
     result = _TOKEN_PATTERN.sub(repl, text)
-    if bold:
-        parts = re.split(r"(\$[^$]*\$)", result)
-        result = "".join(
-            f"\\textbf{{{part}}}" if part and not part.startswith("$") else part
-            for part in parts
-            if part
-        )
     return result
 
 

--- a/tests/test_split_signature.py
+++ b/tests/test_split_signature.py
@@ -19,7 +19,7 @@ def test_split_signature_basic():
 def test_split_signature_bold():
     parts = split_signature('Момент M_x', bold=True)
     assert parts == [
-        ('\\textbf{Момент }', False),
+        ('Момент ', False),
         ('\\boldsymbol{\\mathit{M}_{\\mathit{x}}}', True),
     ]
 

--- a/tests/test_title_formatting.py
+++ b/tests/test_title_formatting.py
@@ -64,7 +64,7 @@ def test_titles_bold_italic_math(title, xlabel, expected_tokens):
     for token in expected_tokens:
         assert token in ax.get_title()
 
-    assert r"\textbf" in ax.get_title()
+    assert r"\textbf" not in ax.get_title()
 
     assert ax.get_xlabel() == formatted_label
     assert ax.get_ylabel() == formatted_label

--- a/tests/test_title_processor_bold_math.py
+++ b/tests/test_title_processor_bold_math.py
@@ -20,7 +20,7 @@ def test_title_processor_wraps_mathit_with_bold():
         f"${frag}$" if is_latex else frag for frag, is_latex in result
     )
     assert r"\boldsymbol{\mathit{t}}" in joined
-    assert r"\textbf" in joined
+    assert r"\textbf" not in joined
     parser = MathTextParser("agg")
     parser.parse(joined)
 


### PR DESCRIPTION
## Summary
- Убрано оборачивание обычных сегментов в `\textbf` при жирном формате, оставлено только `\boldsymbol` для математики
- Корректировано разбиение сигнатур: текстовые части теперь возвращаются без LaTeX-команд
- Обновлены тесты под новое поведение форматирования

## Testing
- `pytest tests/test_split_signature.py tests/test_title_formatting.py tests/test_title_processor_bold_math.py tests/test_format_signature.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9d3ae9354832a97debd3e3df30f9e