### PR TITLE
Center Y-axis label rendering

### DIFF
--- a/tabs/function_for_all_tabs/plotting.py
+++ b/tabs/function_for_all_tabs/plotting.py
@@ -256,6 +256,60 @@ def create_plot(
                 txt.remove()
             return total
 
+        def _segments_height(segments: List[Tuple[str, bool]]) -> float:
+            """Вычислить суммарную высоту сегментов в координатах осей."""
+            trans = ax.transAxes
+            renderer = fig.canvas.get_renderer()
+            total = 0.0
+            for frag, is_latex in segments:
+                if is_latex:
+                    txt = ax.text(
+                        0.0,
+                        0.0,
+                        f"${frag}$",
+                        transform=trans,
+                        usetex=True,
+                        ha="center",
+                        va="bottom",
+                        rotation=90,
+                    )
+                    try:
+                        bbox = txt.get_window_extent(renderer=renderer)
+                    except RuntimeError:
+                        txt.remove()
+                        txt = ax.text(
+                            0.0,
+                            0.0,
+                            f"${frag}$",
+                            transform=trans,
+                            usetex=False,
+                            ha="center",
+                            va="bottom",
+                            rotation=90,
+                        )
+                        bbox = txt.get_window_extent(renderer=renderer)
+                else:
+                    with mpl.rc_context(
+                        {"text.usetex": False, "font.family": "Times New Roman"}
+                    ):
+                        txt = ax.text(
+                            0.0,
+                            0.0,
+                            frag,
+                            transform=trans,
+                            ha="center",
+                            va="bottom",
+                            rotation=90,
+                        )
+                        bbox = txt.get_window_extent(renderer=renderer)
+                dy = (
+                    ax.transAxes.inverted().transform((0, bbox.height))[1]
+                    - ax.transAxes.inverted().transform((0, 0))[1]
+                )
+                total += dy
+                txt.remove()
+            return total
+
         _render_segments(
             title,
             x=0.0,
@@ -278,16 +332,19 @@ def create_plot(
             ha="left",
             va="center",
         )
+        ax.set_ylabel("", labelpad=15, ha="center")
+        height = _segments_height(y_label)
+        start_y = 0.5 + height / 2
         _render_segments(
             y_label,
-            x=-0.1,
-            y=1.0,
+            x=0.0,
+            y=start_y,
             vertical=True,
             rotation=90,
             fontweight="normal",
             fontstyle="normal",
             fontsize=12,
-            ha="center",
+            ha="right",
             va="top",
         )
 

--- a/tests/test_segment_rendering.py
+++ b/tests/test_segment_rendering.py
@@ -60,3 +60,30 @@ def test_x_label_is_centered():
     expected_start = 0.5 - 1.5 * w1
     assert abs(a_text.get_position()[0] - expected_start) < 1e-6
     plt.close(fig)
+
+
+def test_y_label_is_centered_and_non_negative():
+    plt.rcParams.update({"text.usetex": False})
+    fig, ax = plt.subplots()
+    curves = [{"X_values": [0, 1], "Y_values": [0, 1]}]
+    x_label = split_signature("X", bold=False)
+    y_label = [("A", False), ("B", False)]
+
+    def fake_extent(self, renderer=None):
+        heights = {"A": 10, "B": 20, "X": 10}
+        h = heights.get(self.get_text(), 10)
+        return Bbox.from_bounds(0, 0, 1, h)
+
+    with patch("matplotlib.text.Text.get_window_extent", fake_extent), patch(
+        "tabs.function_for_all_tabs.plotting.configure_matplotlib",
+        lambda: plt.rcParams.update({"text.usetex": False}),
+    ):
+        create_plot(curves, x_label, y_label, [], fig=fig, ax=ax)
+
+    a_text = next(t for t in ax.texts if t.get_text() == "A")
+    b_text = next(t for t in ax.texts if t.get_text() == "B")
+    h1 = a_text.get_position()[1] - b_text.get_position()[1]
+    expected_start = 0.5 + 1.5 * h1
+    assert abs(a_text.get_position()[1] - expected_start) < 1e-6
+    assert a_text.get_position()[0] >= 0
+    plt.close(fig)


### PR DESCRIPTION
## Summary
- align y-axis label segments around axis center
- remove negative coordinates for Y label using labelpad
- cover Y label positioning with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9d65af224832aa711a8cba5f8d044