### PR TITLE
Use format_signature for titles

### DIFF
--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -18,7 +18,7 @@ from tabs.constants import (
     UNITS_MAPPING,
     UNITS_MAPPING_EN,
 )
-from tabs.title_utils import split_signature
+from tabs.title_utils import split_signature, format_signature
 
 logger = logging.getLogger(__name__)
 
@@ -84,8 +84,8 @@ class TitleProcessor:
             self.language, self.combo_title.get()
         )
 
-    def get_processed_title(self) -> list[tuple[str, bool]]:
-        """Вернуть заголовок в виде сегментов ``split_signature``."""
+    def get_processed_title(self) -> str:
+        """Вернуть заголовок с оформленными обозначениями."""
         selection = self.combo_title.get()
         if selection in ("Другое", ""):
             result = self.entry_title.get() if self.entry_title else ""
@@ -94,7 +94,7 @@ class TitleProcessor:
         else:
             title = self._get_title()
             result = f"{title}{self._get_units()}"
-        return split_signature(result, bold=self.bold_math)
+        return format_signature(result, bold=self.bold_math)
 
 def save_file(entry_widget, format_widget, graph_info):
 
@@ -172,6 +172,7 @@ def generate_graph(
         combo_titleX_size,
         entry_titleX,
         language,
+        bold_math=False,
         translations=TITLE_TRANSLATIONS,
     )
     ylabel_processor = TitleProcessor(
@@ -179,11 +180,12 @@ def generate_graph(
         combo_titleY_size,
         entry_titleY,
         language,
+        bold_math=False,
         translations=TITLE_TRANSLATIONS,
     )
-    title = title_processor.get_processed_title()
-    xlabel = xlabel_processor.get_processed_title()
-    ylabel = ylabel_processor.get_processed_title()
+    title = split_signature(title_processor.get_processed_title(), bold=False)
+    xlabel = split_signature(xlabel_processor.get_processed_title(), bold=False)
+    ylabel = split_signature(ylabel_processor.get_processed_title(), bold=False)
 
     # Текст заголовка передается без LaTeX-команд,
     # оформление выполняется через параметры Matplotlib.

--- a/tests/test_title_processor_bold_math.py
+++ b/tests/test_title_processor_bold_math.py
@@ -15,10 +15,7 @@ class ComboStub:
 def test_title_processor_wraps_mathit_with_bold():
     combo_title = ComboStub("Время")
     processor = TitleProcessor(combo_title, bold_math=True)
-    result = processor.get_processed_title()
-    joined = "".join(
-        f"${frag}$" if is_latex else frag for frag, is_latex in result
-    )
+    joined = processor.get_processed_title()
     assert r"\boldsymbol{\mathit{t}}" in joined
     assert r"\textbf" not in joined
     parser = MathTextParser("agg")
@@ -29,14 +26,8 @@ def test_title_processor_uses_bold_dict_only_for_title():
     combo = ComboStub("Время")
     title_proc = TitleProcessor(combo, bold_math=True)
     axis_proc = TitleProcessor(combo, translations=TITLE_TRANSLATIONS)
-    joined_title = "".join(
-        f"${frag}$" if is_latex else frag
-        for frag, is_latex in title_proc.get_processed_title()
-    )
-    joined_axis = "".join(
-        f"${frag}$" if is_latex else frag
-        for frag, is_latex in axis_proc.get_processed_title()
-    )
+    joined_title = title_proc.get_processed_title()
+    joined_axis = axis_proc.get_processed_title()
     assert r"\boldsymbol{\mathit{t}}" in joined_title
     assert r"\boldsymbol{\mathit{t}}" not in joined_axis
 
@@ -45,10 +36,7 @@ def test_title_processor_wraps_multiple_mathit_occurrences():
     combo_title = ComboStub("Другое")
     entry = ComboStub("Value $\\mathit{x}+\\mathit{y}$")
     processor = TitleProcessor(combo_title, entry_title=entry, bold_math=True)
-    result = processor.get_processed_title()
-    joined = "".join(
-        f"${frag}$" if is_latex else frag for frag, is_latex in result
-    )
+    joined = processor.get_processed_title()
     assert joined.count(r"\boldsymbol{\mathit{") == 2
     parser = MathTextParser("agg")
     parser.parse(joined)
@@ -58,10 +46,7 @@ def test_title_processor_wraps_M_symbols_and_preserves_math():
     combo_title = ComboStub("Другое")
     entry = ComboStub("M_x My $M_z$ $v$ \\boldsymbol{My}")
     processor = TitleProcessor(combo_title, entry_title=entry, bold_math=True)
-    result = processor.get_processed_title()
-    joined = "".join(
-        f"${frag}$" if is_latex else frag for frag, is_latex in result
-    )
+    joined = processor.get_processed_title()
     assert r"\boldsymbol{\mathit{M}_{\mathit{x}}}" in joined
     assert joined.count(r"\boldsymbol{My}") == 1
     assert " My " in joined

--- a/tests/test_title_processor_translation.py
+++ b/tests/test_title_processor_translation.py
@@ -19,9 +19,6 @@ def test_title_processor_translates_to_english():
         language="Английский",
         translations=TITLE_TRANSLATIONS,
     )
-    result = processor.get_processed_title()
-    joined = "".join(
-        f"${frag}$" if is_latex else frag for frag, is_latex in result
-    )
+    joined = processor.get_processed_title()
     assert "Force" in joined
     assert ", kN" in joined


### PR DESCRIPTION
## Summary
- format graph titles and labels via `format_signature`
- adjust TitleProcessor API to return formatted strings
- update tests for new TitleProcessor behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9e0cabd50832ab08536dfdc5a6784