### PR TITLE
Упростить API построения графиков

### DIFF
--- a/tabs/function_for_all_tabs/plotting_adapter.py
+++ b/tabs/function_for_all_tabs/plotting_adapter.py
@@ -7,7 +7,7 @@ from matplotlib.figure import Figure
 from matplotlib.axes import Axes
 
 from tabs.function_for_all_tabs import create_plot
-from tabs.title_utils import split_signature
+from tabs.title_utils import format_signature
 
 Curve = Dict[str, List[float]]
 
@@ -34,14 +34,14 @@ def plot_on_canvas(
 ) -> None:
     """Clear ``ax`` and render ``curves`` using shared style utilities."""
     ax.clear()
-    title_segments = split_signature(title, bold=True)
-    x_segments = split_signature(x_label, bold=False)
-    y_segments = split_signature(y_label, bold=False)
+    title_formatted = format_signature(title, bold=True)
+    x_formatted = format_signature(x_label, bold=False)
+    y_formatted = format_signature(y_label, bold=False)
     create_plot(
         curves,
-        x_segments,
-        y_segments,
-        title_segments,
+        x_formatted,
+        y_formatted,
+        title_formatted,
         pr_y=pr_y,
         fig=fig,
         ax=ax,

--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -18,7 +18,7 @@ from tabs.constants import (
     UNITS_MAPPING,
     UNITS_MAPPING_EN,
 )
-from tabs.title_utils import split_signature, format_signature
+from tabs.title_utils import format_signature
 
 logger = logging.getLogger(__name__)
 
@@ -183,9 +183,9 @@ def generate_graph(
         bold_math=False,
         translations=TITLE_TRANSLATIONS,
     )
-    title = split_signature(title_processor.get_processed_title(), bold=False)
-    xlabel = split_signature(xlabel_processor.get_processed_title(), bold=False)
-    ylabel = split_signature(ylabel_processor.get_processed_title(), bold=False)
+    title = title_processor.get_processed_title()
+    xlabel = xlabel_processor.get_processed_title()
+    ylabel = ylabel_processor.get_processed_title()
 
     # Текст заголовка передается без LaTeX-команд,
     # оформление выполняется через параметры Matplotlib.

--- a/tabs/functions_for_tab3/plotting.py
+++ b/tabs/functions_for_tab3/plotting.py
@@ -3,7 +3,7 @@ from tabs.functions_for_tab3.Figurenameclass import FigureNames
 from widgets.message_log import message_log
 
 from tabs.function_for_all_tabs import create_plot
-from tabs.title_utils import split_signature
+from tabs.title_utils import format_signature
 
 
 def create_png_plots(graph_with_time, file_path_outeig, log_text):
@@ -11,7 +11,7 @@ def create_png_plots(graph_with_time, file_path_outeig, log_text):
 
     for name, graph in graph_with_time.items():
         X_values = [float(item[0]) for item in graph]
-        xlabel = split_signature("Время t, с", bold=False)
+        xlabel = format_signature("Время t, с", bold=False)
         namefig = FigureNames(name)
 
         keys = ["XR", "YR", "ZR", "X", "Y", "Z"]
@@ -31,8 +31,8 @@ def create_png_plots(graph_with_time, file_path_outeig, log_text):
             create_plot(
                 curves_info,
                 xlabel,
-                split_signature(namefig.generate_plot_ylabel(), bold=False),
-                split_signature(namefig.generate_plot_title(), bold=True),
+                format_signature(namefig.generate_plot_ylabel(), bold=False),
+                format_signature(namefig.generate_plot_title(), bold=True),
                 pr_y=True,
                 save_file=True,
                 file_plt=file_plt,
@@ -43,8 +43,8 @@ def create_png_plots(graph_with_time, file_path_outeig, log_text):
             create_plot(
                 curves_info,
                 xlabel,
-                split_signature(namefig.generate_plot_ylabel(), bold=False),
-                split_signature(namefig.generate_plot_title(), bold=True),
+                format_signature(namefig.generate_plot_ylabel(), bold=False),
+                format_signature(namefig.generate_plot_title(), bold=True),
                 pr_y=False,
                 save_file=True,
                 file_plt=file_plt,

--- a/tests/test_create_plot_fontstyle.py
+++ b/tests/test_create_plot_fontstyle.py
@@ -7,19 +7,23 @@ import matplotlib.pyplot as plt
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 from tabs.function_for_all_tabs import create_plot
-from tabs.title_utils import split_signature
+from unittest.mock import patch
 
 
 def test_default_title_fontstyle_normal():
     fig, ax = plt.subplots()
     curves = [{"X_values": [0, 1], "Y_values": [0, 1]}]
-    create_plot(
-        curves,
-        split_signature("X", bold=False),
-        split_signature("Y", bold=False),
-        split_signature("Title", bold=True),
-        fig=fig,
-        ax=ax,
-    )
-    assert ax.texts[0].get_fontstyle() == "normal"
+    with patch(
+        "tabs.function_for_all_tabs.plotting.configure_matplotlib", lambda: None
+    ):
+        plt.rcParams.update({"text.usetex": False})
+        create_plot(
+            curves,
+            "X",
+            "Y",
+            "Title",
+            fig=fig,
+            ax=ax,
+        )
+    assert ax.title.get_fontstyle() == "normal"
     plt.close(fig)

--- a/tests/test_last_graph_save_file.py
+++ b/tests/test_last_graph_save_file.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 
 from tabs.functions_for_tab1 import plotting
 from tabs import tab1
-from tabs.title_utils import split_signature
 
 
 def test_save_file_uses_updated_last_graph(tmp_path):
@@ -23,9 +22,9 @@ def test_save_file_uses_updated_last_graph(tmp_path):
     plotting.last_graph.update(
         {
             "curves_info": [{"X_values": [0, 1], "Y_values": [0, 1]}],
-            "x_label": split_signature("X", bold=False),
-            "y_label": split_signature("Y", bold=False),
-            "title": split_signature("T", bold=True),
+            "x_label": "X",
+            "y_label": "Y",
+            "title": "T",
             "fig": fig,
         }
     )

--- a/tests/test_segment_rendering.py
+++ b/tests/test_segment_rendering.py
@@ -1,89 +1,35 @@
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
-from matplotlib.transforms import Bbox
+import pytest
 from unittest.mock import patch
 
 from tabs.function_for_all_tabs.plotting import create_plot
-from tabs.title_utils import split_signature
 
 
-def test_segments_usetex_and_font():
-    plt.rcParams.update({"text.usetex": False})
+def test_labels_applied():
     fig, ax = plt.subplots()
+    plt.rcParams.update({"text.usetex": False})
     curves = [{"X_values": [0, 1], "Y_values": [0, 1]}]
-    title = split_signature("Title M_x", bold=False)
     with patch(
-        "matplotlib.text.Text.get_window_extent",
-        return_value=Bbox.from_bounds(0, 0, 1, 1),
-    ), patch(
         "tabs.function_for_all_tabs.plotting.configure_matplotlib",
         lambda: plt.rcParams.update({"text.usetex": False}),
     ):
-        create_plot(
-            curves,
-            split_signature("X", bold=False),
-            split_signature("Y", bold=False),
-            title,
-            fig=fig,
-            ax=ax,
-        )
-    plain = next(t for t in ax.texts if t.get_text() == "Title ")
-    latex = next(t for t in ax.texts if t.get_text() == "$\\mathit{M}_{\\mathit{x}}$")
-    assert not plain.get_usetex()
-    assert "Times New Roman" in plain.get_fontfamily()
-    assert latex.get_usetex()
+        create_plot(curves, "X", "Y", "Title", fig=fig, ax=ax)
+    assert ax.get_xlabel() == "X"
+    assert ax.get_ylabel() == "Y"
+    assert ax.get_title() == "Title"
     plt.close(fig)
 
 
-def test_x_label_is_centered():
-    plt.rcParams.update({"text.usetex": False})
+def test_invalid_latex_raises():
     fig, ax = plt.subplots()
+    plt.rcParams.update({"text.usetex": False})
     curves = [{"X_values": [0, 1], "Y_values": [0, 1]}]
-    x_label = [("A", False), ("B", False)]
-    y_label = split_signature("Y", bold=False)
-
-    def fake_extent(self, renderer=None):
-        widths = {"A": 10, "B": 20, "Y": 10}
-        w = widths.get(self.get_text(), 10)
-        return Bbox.from_bounds(0, 0, w, 1)
-
-    with patch("matplotlib.text.Text.get_window_extent", fake_extent), patch(
+    with patch(
         "tabs.function_for_all_tabs.plotting.configure_matplotlib",
         lambda: plt.rcParams.update({"text.usetex": False}),
     ):
-        create_plot(curves, x_label, y_label, [], fig=fig, ax=ax)
-
-    a_text = next(t for t in ax.texts if t.get_text() == "A")
-    b_text = next(t for t in ax.texts if t.get_text() == "B")
-    w1 = b_text.get_position()[0] - a_text.get_position()[0]
-    expected_start = 0.5 - 1.5 * w1
-    assert abs(a_text.get_position()[0] - expected_start) < 1e-6
-    plt.close(fig)
-
-
-def test_y_label_is_centered_and_non_negative():
-    plt.rcParams.update({"text.usetex": False})
-    fig, ax = plt.subplots()
-    curves = [{"X_values": [0, 1], "Y_values": [0, 1]}]
-    x_label = split_signature("X", bold=False)
-    y_label = [("A", False), ("B", False)]
-
-    def fake_extent(self, renderer=None):
-        heights = {"A": 10, "B": 20, "X": 10}
-        h = heights.get(self.get_text(), 10)
-        return Bbox.from_bounds(0, 0, 1, h)
-
-    with patch("matplotlib.text.Text.get_window_extent", fake_extent), patch(
-        "tabs.function_for_all_tabs.plotting.configure_matplotlib",
-        lambda: plt.rcParams.update({"text.usetex": False}),
-    ):
-        create_plot(curves, x_label, y_label, [], fig=fig, ax=ax)
-
-    a_text = next(t for t in ax.texts if t.get_text() == "A")
-    b_text = next(t for t in ax.texts if t.get_text() == "B")
-    h1 = a_text.get_position()[1] - b_text.get_position()[1]
-    expected_start = 0.5 + 1.5 * h1
-    assert abs(a_text.get_position()[1] - expected_start) < 1e-6
-    assert a_text.get_position()[0] >= 0
+        with pytest.raises(ValueError):
+            create_plot(curves, "X$", "Y", "Title", fig=fig, ax=ax)
     plt.close(fig)


### PR DESCRIPTION
## Summary
- упростил `create_plot`: подписи и заголовок принимают строки, используются стандартные методы `Axes`
- адаптировал вызовы и обработку подписей в других модулях
- обновил тесты под новое API

## Testing
- `pytest` *(ошибка: Failed to process string with tex because latex could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e2717430832a9768f8e3ea3983aa