### PR TITLE
docs: обновить пример форматирования

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,9 @@ This opens the GUI where you can create and customize plots across multiple tabs
 Для заголовков графиков и подписей осей доступны две функции из модуля
 `tabs.title_utils`:
 
+- `format_signature` — возвращает строку, готовую к передаче в Matplotlib;
 - `split_signature` — разбивает исходный текст на сегменты вида
-  `(фрагмент, is_latex)`;
-- `format_signature` — обёртка, объединяющая сегменты в строку для
-  обратной совместимости.
+  `(фрагмент, is_latex)` для нестандартных сценариев оформления.
 
 Обе функции переводят латинские буквы в курсив (`\mathit{}`), заменяют
 греческие символы на команды пакета `upgreek` и корректно обрабатывают
@@ -52,31 +51,25 @@ This opens the GUI where you can create and customize plots across multiple tabs
 
 Примеры:
 
-- `join_segments(split_signature('Момент M_x', bold=True))` → «Момент
+- `format_signature('Момент M_x', bold=True)` → «Момент
   $\boldsymbol{\mathit{M}_{\mathit{x}}}$»
-- `split_signature('Угол α', bold=False)` → `[('Угол ', False),
-  ('\\upalpha', True)]`
-- `split_signature('Напряжение σ_{max}', bold=False)` →
-  `[('Напряжение ', False),
-  ('\\upsigma_{\\mathit{max}}', True)]`
+- `format_signature('Угол α', bold=False)` → «Угол $\upalpha$»
+- `format_signature('Напряжение σ_{max}', bold=False)` →
+  «Напряжение $\upsigma_{\mathit{max}}$»
 
 ### Пример использования с Matplotlib
 
 ```python
 import matplotlib.pyplot as plt
 from settings import configure_matplotlib
-from tabs.title_utils import split_signature
-
-
-def join_segments(parts):
-    return ''.join(f'${frag}$' if is_latex else frag for frag, is_latex in parts)
+from tabs.title_utils import format_signature
 
 configure_matplotlib()
 
 fig, ax = plt.subplots()
-ax.set_title(join_segments(split_signature('Момент M_x', bold=True)))
-ax.set_xlabel(join_segments(split_signature('Угол α', bold=False)))
-ax.set_ylabel(join_segments(split_signature('Напряжение σ_{max}', bold=False)))
+ax.set_title(format_signature('Момент M_x', bold=True))
+ax.set_xlabel(format_signature('Угол α', bold=False))
+ax.set_ylabel(format_signature('Напряжение σ_{max}', bold=False))
 plt.show()
 ```
 
@@ -93,7 +86,7 @@ The axis dimension selectors support both SI units and engineering units based o
 
 ## Example: Combined Labels
 
-The script [`examples/combined_labels.py`](examples/combined_labels.py) demonstrates how to use `split_signature` to mix bold designations in the title with italic or upright symbols in axis labels.
+The script [`examples/combined_labels.py`](examples/combined_labels.py) demonstrates how to use `format_signature` to mix bold designations in the title with italic or upright symbols in axis labels.
 
 Run the example with:
 

--- a/examples/combined_labels.py
+++ b/examples/combined_labels.py
@@ -3,17 +3,11 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 
-# Пример демонстрирует использование нового API ``split_signature``,
-# возвращающего список сегментов для последующей отрисовки.
+# Пример демонстрирует использование функции ``format_signature``,
+# возвращающей строку с корректно оформленными обозначениями.
 # Ensure project root is on sys.path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from tabs.title_utils import split_signature
-
-
-def join_segments(parts):
-    """Объединить сегменты ``split_signature`` в строку."""
-
-    return "".join(f"${frag}$" if is_latex else frag for frag, is_latex in parts)
+from tabs.title_utils import format_signature
 
 x = [0, 1, 2, 3]
 y = [0, 1, 4, 9]
@@ -21,8 +15,8 @@ y = [0, 1, 4, 9]
 fig, ax = plt.subplots()
 ax.plot(x, y)
 
-ax.set_title(join_segments(split_signature("Сила F_x при угле α", bold=True)))
-ax.set_xlabel(join_segments(split_signature("Время t, с", bold=False)))
-ax.set_ylabel(join_segments(split_signature("Угол α, рад", bold=False)))
+ax.set_title(format_signature("Сила F_x при угле α", bold=True))
+ax.set_xlabel(format_signature("Время t, с", bold=False))
+ax.set_ylabel(format_signature("Угол α, рад", bold=False))
 
 plt.show()


### PR DESCRIPTION
## Summary
- replace split_signature with format_signature in example
- document format_signature as primary API

## Testing
- `pytest` *(fails: Failed to process string with tex because latex could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e620bd90832a9aad1d2f4f100c44