### PR TITLE
Использовать размеры шрифтов из rcParams

### DIFF
--- a/tabs/function_for_all_tabs/plotting.py
+++ b/tabs/function_for_all_tabs/plotting.py
@@ -15,6 +15,12 @@ from tabs.title_utils import format_signature
 
 logger = logging.getLogger(__name__)
 
+# Значения размеров шрифтов по умолчанию из rcParams.
+# Эти константы обновляются при каждом вызове ``create_plot``
+# после применения пользовательской конфигурации Matplotlib.
+TITLE_SIZE = plt.rcParams["axes.titlesize"]
+LABEL_SIZE = plt.rcParams["axes.labelsize"]
+
 
 def create_plot(
     curves_info: List[Dict[str, List[float]]],
@@ -51,6 +57,10 @@ def create_plot(
     logger.info("Начало построения графика")
     old_usetex = plt.rcParams.get("text.usetex", False)
     configure_matplotlib()
+    # Обновляем размеры шрифтов после применения конфигурации
+    global TITLE_SIZE, LABEL_SIZE
+    TITLE_SIZE = plt.rcParams["axes.titlesize"]
+    LABEL_SIZE = plt.rcParams["axes.labelsize"]
     if "prY" in kwargs:
         warnings.warn("prY is deprecated, use pr_y", DeprecationWarning, stacklevel=2)
         logger.warning("Использован устаревший параметр prY")
@@ -123,7 +133,7 @@ def create_plot(
                 title,
                 fontweight="bold",
                 fontstyle=title_fontstyle,
-                fontsize=16,
+                fontsize=TITLE_SIZE,
                 loc="left",
                 usetex=True,
             )
@@ -132,7 +142,7 @@ def create_plot(
                 title,
                 fontweight="bold",
                 fontstyle=title_fontstyle,
-                fontsize=16,
+                fontsize=TITLE_SIZE,
                 loc="left",
                 usetex=False,
             )
@@ -141,7 +151,7 @@ def create_plot(
                 x_label,
                 fontweight="normal",
                 fontstyle="normal",
-                fontsize=12,
+                fontsize=LABEL_SIZE,
                 usetex=True,
             )
         except RuntimeError:
@@ -149,7 +159,7 @@ def create_plot(
                 x_label,
                 fontweight="normal",
                 fontstyle="normal",
-                fontsize=12,
+                fontsize=LABEL_SIZE,
                 usetex=False,
             )
         try:
@@ -157,7 +167,7 @@ def create_plot(
                 y_label,
                 fontweight="normal",
                 fontstyle="normal",
-                fontsize=12,
+                fontsize=LABEL_SIZE,
                 usetex=True,
             )
         except RuntimeError:
@@ -165,7 +175,7 @@ def create_plot(
                 y_label,
                 fontweight="normal",
                 fontstyle="normal",
-                fontsize=12,
+                fontsize=LABEL_SIZE,
                 usetex=False,
             )
 

--- a/tests/test_create_plot_fontstyle.py
+++ b/tests/test_create_plot_fontstyle.py
@@ -5,12 +5,14 @@ import sys
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
+from matplotlib.font_manager import FontProperties
 from unittest.mock import patch
 
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 from tabs.function_for_all_tabs import create_plot
+from tabs.function_for_all_tabs.plotting import TITLE_SIZE, LABEL_SIZE
 
 
 @pytest.mark.skipif(shutil.which("latex") is None, reason="LaTeX not installed")
@@ -29,5 +31,10 @@ def test_default_title_fontstyle_normal():
             fig=fig,
             ax=ax,
         )
+    expected_title_size = FontProperties(size=TITLE_SIZE).get_size_in_points()
+    expected_label_size = FontProperties(size=LABEL_SIZE).get_size_in_points()
     assert ax.title.get_fontstyle() == "normal"
+    assert ax.title.get_fontsize() == expected_title_size
+    assert ax.xaxis.label.get_fontsize() == expected_label_size
+    assert ax.yaxis.label.get_fontsize() == expected_label_size
     plt.close(fig)


### PR DESCRIPTION
## Summary
- убрать жестко заданные размеры шрифтов и получать их из rcParams
- обновить тесты, проверяющие размеры шрифта заголовка и подписей осей

## Testing
- `pytest tests/test_create_plot_fontstyle.py tests/test_generate_graph_title_fontstyle.py -q` *(skipped: LaTeX not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f484b834832a8e1c049317dc6fc3