### PR TITLE
Сделать текст заголовков жирным при форматировании

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ This opens the GUI where you can create and customize plots across multiple tabs
 
 Функция `format_signature` переводит латинские буквы в курсив
 (`\mathit{}`), заменяет греческие символы на команды пакета `upgreek` и
-корректно обрабатывает индексы/степени. Параметр `bold=True`
-дополнительно оборачивает обозначения в `\boldsymbol{}`. Сегментный API
-(`split_signature`/`join_segments`) устарел и не рекомендуется к
-использованию.
+корректно обрабатывает индексы/степени. Параметр `bold=True` делает
+текстовые части жирными и оборачивает обозначения в `\boldsymbol{}`.
+Сегментный API (`split_signature`/`join_segments`) устарел и не
+рекомендуется к использованию.
 
 Примеры:
 
-- `format_signature('Момент M_x', bold=True)` → «Момент
+- `format_signature('Момент M_x', bold=True)` → «\textbf{Момент }
   $\boldsymbol{\mathit{M}_{\mathit{x}}}$»
 - `format_signature('Угол α', bold=False)` → «Угол $\upalpha$»
 - `format_signature('Напряжение σ_{max}', bold=False)` →

--- a/tabs/title_utils.py
+++ b/tabs/title_utils.py
@@ -121,12 +121,15 @@ def split_signature(text: str, bold: bool) -> list[tuple[str, bool]]:
 
     Латинские и греческие обозначения преобразуются в LaTeX так же, как в
     :func:`format_signature`. Сегменты с ``is_latex=True`` предназначены для
-    отображения в математическом режиме.
+    отображения в математическом режиме. При ``bold=True`` текстовые части
+    дополнительно оборачиваются в ``\textbf{...}``.
 
     Пример
     -------
     >>> split_signature('Угол α', bold=False)
     [('Угол ', False), ('\\upalpha', True)]
+    >>> split_signature('Угол α', bold=True)
+    [('\\textbf{Угол }', False), ('\\boldsymbol{\\upalpha}', True)]
     """
 
     formatted = _format_signature_impl(text, bold)
@@ -138,7 +141,7 @@ def split_signature(text: str, bold: bool) -> list[tuple[str, bool]]:
         if part.startswith("$") and part.endswith("$"):
             segments.append((part[1:-1], True))
         else:
-            segments.append((part, False))
+            segments.append((f"\\textbf{{{part}}}" if bold else part, False))
     return segments
 
 

--- a/tests/test_format_signature.py
+++ b/tests/test_format_signature.py
@@ -35,4 +35,4 @@ def test_greek_upright():
 def test_bold_true():
     result = format_signature('Сила F_x', bold=True)
     _parse_or_fail(result)
-    assert result == 'Сила $\\boldsymbol{\\mathit{F}_{\\mathit{x}}}$'
+    assert result == r"\textbf{Сила }$\boldsymbol{\mathit{F}_{\mathit{x}}}$"

--- a/tests/test_split_signature.py
+++ b/tests/test_split_signature.py
@@ -21,12 +21,12 @@ def test_format_signature_basic():
 def test_format_signature_bold():
     result = format_signature('Момент M_x', bold=True)
     parser.parse(result)
-    assert result == 'Момент $\\boldsymbol{\\mathit{M}_{\\mathit{x}}}$'
+    assert result == r"\textbf{Момент }$\boldsymbol{\mathit{M}_{\mathit{x}}}$"
 
 
 def test_format_signature_roundtrip():
     text = 'Сила F_x'
     formatted = format_signature(text, bold=True)
     parser.parse(formatted)
-    assert formatted == 'Сила $\\boldsymbol{\\mathit{F}_{\\mathit{x}}}$'
+    assert formatted == r"\textbf{Сила }$\boldsymbol{\mathit{F}_{\mathit{x}}}$"
 

--- a/tests/test_title_formatting.py
+++ b/tests/test_title_formatting.py
@@ -61,7 +61,9 @@ def test_titles_bold_italic_math(title, xlabel, expected_tokens):
     for token in expected_tokens:
         assert token in ax.get_title()
 
-    assert r"\textbf" not in ax.get_title()
+    assert r"\textbf{" in ax.get_title()
+    assert r"\textbf{" not in ax.get_xlabel()
+    assert r"\textbf{" not in ax.get_ylabel()
 
     assert ax.get_xlabel() == formatted_label
     assert ax.get_ylabel() == formatted_label
@@ -112,6 +114,12 @@ def test_format_signature_with_super_and_sub(token, bold, expected):
     sanitized = formatted.replace("\\upsigma", "\\sigma").replace("\\uplambda", "\\lambda")
     parser.parse(sanitized)
     assert formatted == f"${expected}$"
+
+
+def test_format_signature_bold_text_only():
+    formatted = format_signature("Просто текст", bold=True)
+    parser.parse(formatted)
+    assert formatted == r"\textbf{Просто текст}"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_title_processor_bold_math.py
+++ b/tests/test_title_processor_bold_math.py
@@ -19,7 +19,7 @@ def test_title_processor_wraps_mathit_with_bold():
     joined = processor.get_processed_title()
     expected = format_signature(TITLE_TRANSLATIONS["Время"]["Русский"], bold=True)
     assert joined == expected
-    assert r"\textbf" not in joined
+    assert r"\textbf" in joined
     parser = MathTextParser("agg")
     parser.parse(joined)
 


### PR DESCRIPTION
## Summary
- Текстовые части заголовков оборачиваются в `\textbf{}` при параметре `bold=True`
- Обновлена документация и тесты для проверки нового поведения

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9f84d1248832aad167bd458779b44