### PR TITLE
Фикс вычисления смещения по Y

### DIFF
--- a/tabs/function_for_all_tabs/plotting.py
+++ b/tabs/function_for_all_tabs/plotting.py
@@ -162,6 +162,25 @@ def create_plot(
                 fontsize=LABEL_SIZE,
                 usetex=False,
             )
+        try:
+            ax.set_ylabel(
+                y_label,
+                fontweight="normal",
+                fontstyle="normal",
+                fontsize=LABEL_SIZE,
+                usetex=True,
+            )
+        except RuntimeError:
+            ax.set_ylabel(
+                y_label,
+                fontweight="normal",
+                fontstyle="normal",
+                fontsize=LABEL_SIZE,
+                usetex=False,
+            )
+
+        fig.canvas.draw()
+
         x_offset = ax.xaxis.get_offset_text().get_text()
         if x_offset:
             ax.xaxis.get_offset_text().set_visible(False)
@@ -181,22 +200,6 @@ def create_plot(
                     fontsize=LABEL_SIZE,
                     usetex=False,
                 )
-        try:
-            ax.set_ylabel(
-                y_label,
-                fontweight="normal",
-                fontstyle="normal",
-                fontsize=LABEL_SIZE,
-                usetex=True,
-            )
-        except RuntimeError:
-            ax.set_ylabel(
-                y_label,
-                fontweight="normal",
-                fontstyle="normal",
-                fontsize=LABEL_SIZE,
-                usetex=False,
-            )
         y_offset = ax.yaxis.get_offset_text().get_text()
         if y_offset:
             ax.yaxis.get_offset_text().set_visible(False)


### PR DESCRIPTION
## Summary
- Перестраиваем порядок вычислений в `create_plot`, чтобы смещения по осям формировались после прорисовки
- Добавляем `fig.canvas.draw()` перед чтением смещений

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa2c359c78832aa848faacbcd0913d