### PR TITLE
Скрытие комбобокса подписи легенды при выборе 'Другое'

### DIFF
--- a/tabs/tab1.py
+++ b/tabs/tab1.py
@@ -62,6 +62,7 @@ def on_legend_title_change(
 
     selection = combo.get()
     if selection == other_label:
+        combo.place_forget()
         entry.place(
             x=ui_const.LEGEND_TITLE_ENTRY_X,
             y=ui_const.LEGEND_TITLE_Y,
@@ -70,6 +71,11 @@ def on_legend_title_change(
         combo.set("")
         title_var.set("")
     else:
+        combo.place(
+            x=ui_const.LEGEND_TITLE_COMBO_X,
+            y=ui_const.LEGEND_TITLE_Y,
+            width=ui_const.COMBO_WIDTH,
+        )
         entry.place_forget()
         title_var.set(selection)
 


### PR DESCRIPTION
## Summary
- Скрываем комбобокс подписи легенды при выборе "Другое" и показываем поле ввода
- Возвращаем комбобокс на место при выборе других вариантов

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa3e53c048832a811f28a132e11fe2