### PR TITLE
Сохранение выбора «Другое» для подписи легенды

### DIFF
--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -151,6 +151,7 @@ def generate_graph(
     combo_language,
     legend_title_combo,
     legend_title_entry,
+    legend_title_var,
 ):
 
     # Очистка предыдущего графика
@@ -198,19 +199,24 @@ def generate_graph(
         return
 
     if legend_checkbox.get():
-        selection = legend_title_combo.get() if legend_title_combo else ""
         other_label = LEGEND_TITLE_TRANSLATIONS["Другое"].get(language, "Другое")
         none_label = LEGEND_TITLE_TRANSLATIONS["Нет"].get(language, "Нет")
-        if selection == other_label:
+        selected = legend_title_var.get() if legend_title_var else ""
+        entry_visible = (
+            legend_title_entry.winfo_ismapped()
+            if legend_title_entry and hasattr(legend_title_entry, "winfo_ismapped")
+            else False
+        )
+        if entry_visible or selected == other_label:
             text = legend_title_entry.get().strip() if legend_title_entry else ""
             if not text:
                 messagebox.showwarning("Предупреждение", "Заполните подпись легенды")
                 return
             legend_title = text
-        elif selection == none_label or not selection:
+        elif selected == none_label or not selected:
             legend_title = None
         else:
-            legend_title = selection
+            legend_title = selected
         if legend_title:
             legend_title = format_signature(legend_title, bold=False)
     else:

--- a/tabs/tab1.py
+++ b/tabs/tab1.py
@@ -25,7 +25,7 @@ def on_title_combo_change(
 ) -> None:
     """Обновляет выбор заголовка графика.
 
-    При выборе "Другое" отображает поле ввода и очищает комбобокс.
+    При выборе "Другое" отображает поле ввода и сохраняет выбранный вариант.
     При выборе готового варианта скрывает поле ввода и устанавливает
     выбранный текст в переменную заголовка.
     """
@@ -39,8 +39,7 @@ def on_title_combo_change(
             y=combo.winfo_y(),
             width=ui_const.ENTRY_WIDTH,
         )
-        combo.set("")
-        title_var.set("")
+        title_var.set(other_label)
     else:
         entry.place_forget()
         title_var.set(selection)
@@ -54,7 +53,7 @@ def on_legend_title_change(
 ) -> None:
     """Обрабатывает выбор подписи легенды.
 
-    Если выбран вариант «Другое», показывает поле ввода и очищает комбобокс.
+    Если выбран вариант «Другое», показывает поле ввода и сохраняет выбор.
     Иначе скрывает поле ввода и записывает выбранный текст в переменную.
     """
 
@@ -68,8 +67,7 @@ def on_legend_title_change(
             y=ui_const.LEGEND_TITLE_Y,
             width=ui_const.ENTRY_WIDTH,
         )
-        combo.set("")
-        title_var.set("")
+        title_var.set(other_label)
     else:
         combo.place(
             x=ui_const.LEGEND_TITLE_COMBO_X,
@@ -458,6 +456,7 @@ def create_tab1(notebook: ttk.Notebook) -> None:
                 combo_language,
                 legend_title_combo,
                 legend_title_entry,
+                legend_title_var,
             )
             plot_editor.refresh()
             if not editor_visible["shown"]:

--- a/tests/test_generate_graph_label_error.py
+++ b/tests/test_generate_graph_label_error.py
@@ -38,6 +38,7 @@ def test_generate_graph_invalid_label_markup():
     combo_language = Dummy("Русский")
     legend_title_combo = Dummy("Нет")
     legend_title_entry = Dummy("")
+    legend_title_var = Dummy("Нет")
 
     with pytest.raises(ValueError) as excinfo:
         generate_graph(
@@ -58,6 +59,7 @@ def test_generate_graph_invalid_label_markup():
             combo_language,
             legend_title_combo,
             legend_title_entry,
+            legend_title_var,
         )
     plt.close(fig)
     assert "неправильной разметкой подписи" in str(excinfo.value)

--- a/tests/test_generate_graph_legend_title.py
+++ b/tests/test_generate_graph_legend_title.py
@@ -51,6 +51,7 @@ def test_generate_graph_legend_title_translations(language, option):
     selection = LEGEND_TITLE_TRANSLATIONS[option][language]
     legend_title_combo = Dummy(selection)
     legend_title_entry = Dummy("")
+    legend_title_var = Dummy(selection)
 
     with patch("tabs.function_for_all_tabs.plotting.configure_matplotlib", lambda: None):
         plt.rcParams.update({"text.usetex": False})
@@ -72,6 +73,7 @@ def test_generate_graph_legend_title_translations(language, option):
             combo_language,
             legend_title_combo,
             legend_title_entry,
+            legend_title_var,
         )
 
     legend = ax.get_legend()
@@ -99,6 +101,7 @@ def test_generate_graph_legend_title_custom(language):
     legend_title_combo = Dummy(selection)
     custom_text = "My legend" if language == "Английский" else "Моя легенда"
     legend_title_entry = Dummy(custom_text)
+    legend_title_var = Dummy(selection)
 
     with patch("tabs.function_for_all_tabs.plotting.configure_matplotlib", lambda: None):
         plt.rcParams.update({"text.usetex": False})
@@ -120,6 +123,7 @@ def test_generate_graph_legend_title_custom(language):
             combo_language,
             legend_title_combo,
             legend_title_entry,
+            legend_title_var,
         )
 
     legend = ax.get_legend()

--- a/tests/test_generate_graph_title_fontstyle.py
+++ b/tests/test_generate_graph_title_fontstyle.py
@@ -45,6 +45,7 @@ def test_generate_graph_title_fontstyle_normal():
     combo_language = Dummy("Русский")
     legend_title_combo = Dummy("Нет")
     legend_title_entry = Dummy("")
+    legend_title_var = Dummy("Нет")
 
     with patch("tabs.function_for_all_tabs.plotting.configure_matplotlib", lambda: None):
         plt.rcParams.update({"text.usetex": False})
@@ -66,6 +67,7 @@ def test_generate_graph_title_fontstyle_normal():
             combo_language,
             legend_title_combo,
             legend_title_entry,
+            legend_title_var,
         )
 
     expected_title_size = FontProperties(size=TITLE_SIZE).get_size_in_points()


### PR DESCRIPTION
## Summary
- сохраняем выбор «Другое» в обработчиках заголовков
- корректно определяем текст подписи легенды при отображении поля ввода
- обновлены тесты для нового поведения

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa3edbefc8832abde596cebdfbdb81