### PR TITLE
Поддержка \up-команд в bold_math_symbols

### DIFF
--- a/tabs/title_utils.py
+++ b/tabs/title_utils.py
@@ -183,7 +183,9 @@ def bold_math_symbols(text: str) -> str:
     ``\mathbfit``) and respects existing math mode delimited by ``$``.
     """
 
-    pattern = re.compile(r"\\mathit\{[^}]+\}|\bM(?:_?[xyz])\b")
+    pattern = re.compile(
+        r"\\mathit\{[^}]+\}|\\up[a-zA-Z]+|\bM(?:_?[xyz])\b"
+    )
 
     def is_inside_math(s: str, pos: int) -> bool:
         count = 0

--- a/tests/test_title_formatting.py
+++ b/tests/test_title_formatting.py
@@ -135,7 +135,14 @@ def test_format_designation(token, in_math, expected):
     assert format_designation(token, in_math) == expected
 
 
-def test_bold_math_symbols_uses_format_designation(monkeypatch):
+@pytest.mark.parametrize(
+    "text,expected_calls",
+    [
+        ("M_x", [("M_x", False)]),
+        (r"\upalpha", [(r"\upalpha", False)]),
+    ],
+)
+def test_bold_math_symbols_uses_format_designation(monkeypatch, text, expected_calls):
     calls = []
 
     def fake(token, in_math):
@@ -143,8 +150,24 @@ def test_bold_math_symbols_uses_format_designation(monkeypatch):
         return token
 
     monkeypatch.setattr("tabs.title_utils.format_designation", fake)
-    bold_math_symbols("M_x")
-    assert calls == [("M_x", False)]
+    bold_math_symbols(text)
+    assert calls == expected_calls
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        (r"\upalpha", r"$\boldsymbol{\upalpha}$"),
+        (r"$\upbeta$", r"$\boldsymbol{\upbeta}$"),
+    ],
+)
+def test_bold_math_symbols_handles_upgreek(text, expected):
+    result = bold_math_symbols(text)
+    sanitized = result.replace("\\upalpha", "\\alpha").replace(
+        "\\upbeta", "\\beta"
+    )
+    parser.parse(sanitized)
+    assert result == expected
 
 
 def test_format_title_bolditalic_plain_text():


### PR DESCRIPTION
## Summary
- добавлена поддержка \up-греческих символов в bold_math_symbols
- расширены тесты для проверки выделения греческих символов

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad6e2e214832a8af4f4da24017870