### PR TITLE
Пример: курсивные латинские символы в заголовке

### DIFF
--- a/examples/combined_labels.py
+++ b/examples/combined_labels.py
@@ -15,7 +15,7 @@ y = [0, 1, 4, 9]
 fig, ax = plt.subplots()
 ax.plot(x, y)
 
-ax.set_title(r"Сила $\boldsymbol{F_x}$ при угле $\boldsymbol{\upalpha}$")
+ax.set_title(r"Сила $\boldsymbol{\mathit{F}_{\mathit{x}}}$ при угле $\boldsymbol{\upalpha}$")
 ax.set_xlabel(format_signature("Время t, с", bold=False))
 ax.set_ylabel(format_signature("Угол α, рад", bold=False))
 


### PR DESCRIPTION
## Summary
- Использован курсив для латинских символов F и x в заголовке примера `combined_labels`
- Пример оставляет греческую букву α в прямом начертании

## Testing
- `MPLBACKEND=Agg python examples/combined_labels.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aad820a260832a8d11aeaad6af7557