### PR TITLE
Исправлено форматирование латинских символов в README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ Run the example with:
 python examples/combined_labels.py
 ```
 
-You will get a plot where the title displays bold symbols such as $\boldsymbol{F_x}$ and $\boldsymbol{\upalpha}$, while the axis labels show `$\mathit{t}$` and `$\upalpha$` without bold formatting.
+You will get a plot where the title displays bold symbols such as $\boldsymbol{\mathit{F}_{\mathit{x}}}$ and $\boldsymbol{\upalpha}$, while the axis labels show `$\mathit{t}$` and `$\upalpha$` without bold formatting.


### PR DESCRIPTION
## Summary
- заменён пример в README на использование $\boldsymbol{\mathit{F}_{\mathit{x}}}$ вместо $\boldsymbol{F_x}$
- перепроверены остальные примеры форматирования символов

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad82bebd8832ab56ace2b169914e9