### PR TITLE
Skip formatting within existing LaTeX macros

### DIFF
--- a/tests/test_format_signature.py
+++ b/tests/test_format_signature.py
@@ -36,3 +36,10 @@ def test_bold_true():
     result = format_signature('Сила F_x', bold=True)
     _parse_or_fail(result)
     assert result == r"\textbf{Сила }$\boldsymbol{\mathit{F}_{\mathit{x}}}$"
+
+
+def test_no_nested_dollars_existing_indices():
+    text = 'Касательное напряжение \\uptau_{\\mathit{x}\\mathit{y}}'
+    result = format_signature(text, bold=False)
+    _parse_or_fail(result.replace('\\uptau', '\\tau'))
+    assert result == 'Касательное напряжение $\\uptau_{\\mathit{x}\\mathit{y}}$'


### PR DESCRIPTION
## Summary
- avoid matching characters inside `\mathit{}` or `\up` constructs when formatting signatures
- allow nested braces in indices and preserve existing macros
- add regression test to ensure no nested `$` for preformatted indices

## Testing
- `pytest tests/test_format_signature.py tests/test_split_signature.py -q`
- `pytest tests/test_title_formatting.py tests/test_title_processor_translation.py tests/test_title_processor_bold_math.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aadbe10f38832aa2700cc90bfe87d5