### PR TITLE
Добавлены обозначения My/Mz в названиях моментов

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -7,7 +7,7 @@ def configure_matplotlib():
         'text.usetex': True,
         'font.family': 'serif',
         'font.size': 12,  # Общий размер шрифта
-        'axes.titlesize': 17.28,  # Размер шрифта для заголовков осей
+        'axes.titlesize': 20.74,  # Размер шрифта для заголовков осей
         'axes.labelsize': 14.4,  # Размер шрифта для подписей осей
         'xtick.labelsize': 12,  # Размер шрифта для меток оси X
         'ytick.labelsize': 12,  # Размер шрифта для меток оси Y

--- a/tabs/constants.py
+++ b/tabs/constants.py
@@ -464,16 +464,16 @@ TITLE_TRANSLATIONS = {
         "Английский": r"Bending moment $\mathit{M}_{\mathit{x}}$",
     },
     "Изгибающий момент Ms (My)": {
-        "Русский": r"Изгибающий момент $\mathit{M}_{\mathit{s}}$",
-        "Английский": r"Bending moment $\mathit{M}_{\mathit{s}}$",
+        "Русский": r"Изгибающий момент $\mathit{M}_{\mathit{s}} (\mathit{M}_{\mathit{y}})$",
+        "Английский": r"Bending moment $\mathit{M}_{\mathit{s}} (\mathit{M}_{\mathit{y}})$",
     },
     "Изгибающий момент My": {
         "Русский": r"Изгибающий момент $\mathit{M}_{\mathit{y}}$",
         "Английский": r"Bending moment $\mathit{M}_{\mathit{y}}$",
     },
     "Изгибающий момент Mt (Mz)": {
-        "Русский": r"Изгибающий момент $\mathit{M}_{\mathit{t}}$",
-        "Английский": r"Bending moment $\mathit{M}_{\mathit{t}}$",
+        "Русский": r"Изгибающий момент $\mathit{M}_{\mathit{t}} (\mathit{M}_{\mathit{z}})$",
+        "Английский": r"Bending moment $\mathit{M}_{\mathit{t}} (\mathit{M}_{\mathit{z}})$",
     },
     "Изгибающий момент Mz": {
         "Русский": r"Изгибающий момент $\mathit{M}_{\mathit{z}}$",


### PR DESCRIPTION
## Summary
- Добавлены символы M_y и M_z в локализованные подписи изгибающих моментов
- Настроен размер шрифта заголовков Matplotlib согласно ожиданиям тестов

## Testing
- `python main.py` *(ошибка: no display name and no $DISPLAY environment variable)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aaeb0fcbc0832a9fc380b745b7a698