### PR TITLE
Добавлена схема дерева элементов

### DIFF
--- a/tree_schema.py
+++ b/tree_schema.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+EntityKind = Literal["element", "node"]
+ElementType = Literal["beam", "shell", "solid"]
+
+
+@dataclass
+class FileNode:
+    """Leaf node that represents a particular element or node."""
+
+    id: int
+
+    def to_dict(self) -> dict:
+        return {"id": self.id}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "FileNode":
+        return cls(id=int(data["id"]))
+
+
+@dataclass
+class AnalysisNode:
+    """Node that groups results by analysis type."""
+
+    analysis_type: str
+    children: list[FileNode] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "analysis_type": self.analysis_type,
+            "children": [child.to_dict() for child in self.children],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "AnalysisNode":
+        return cls(
+            analysis_type=data["analysis_type"],
+            children=[FileNode.from_dict(ch) for ch in data.get("children", [])],
+        )
+
+
+@dataclass
+class EntityNode:
+    """Top-level node representing an entity (element or node)."""
+
+    user_name: str
+    entity_kind: EntityKind
+    element_type: ElementType | None = None
+    children: list[AnalysisNode] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        data = {
+            "user_name": self.user_name,
+            "entity_kind": self.entity_kind,
+            "children": [child.to_dict() for child in self.children],
+        }
+        if self.element_type is not None:
+            data["element_type"] = self.element_type
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "EntityNode":
+        return cls(
+            user_name=data["user_name"],
+            entity_kind=data["entity_kind"],
+            element_type=data.get("element_type"),
+            children=[AnalysisNode.from_dict(ch) for ch in data.get("children", [])],
+        )


### PR DESCRIPTION
## Summary
- описана структура дерева для сущностей, типов анализа и идентификаторов

## Testing
- `python -m pytest`
- `ruff check tree_schema.py`
- `flake8 tree_schema.py` *(failed: command not found - flake8 installation blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ab392321e8832a8f6951d13e3488e1