### PR TITLE
Добавлены валидаторы для имен, сущностей и типа анализа

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,46 @@
+import pytest
+
+from validators import (
+    ValidationError,
+    ALLOWED_ANALYSIS_TYPES,
+    ensure_unique_names,
+    validate_entity,
+    validate_filename,
+    validate_analysis_type,
+)
+
+
+def test_unique_names_ok():
+    items = [{"name": "A"}, {"name": "B"}]
+    assert ensure_unique_names(items) == items
+
+
+def test_unique_names_duplicate():
+    items = [{"name": "A"}, {"name": "A"}]
+    with pytest.raises(ValidationError):
+        ensure_unique_names(items)
+
+
+def test_validate_entity_kind():
+    assert validate_entity({"entity_kind": "node"}) == {"entity_kind": "node"}
+    with pytest.raises(ValidationError):
+        validate_entity({"entity_kind": "element"})
+    assert validate_entity({"entity_kind": "element", "element_type": "shell"}) == {
+        "entity_kind": "element",
+        "element_type": "shell",
+    }
+    with pytest.raises(ValidationError):
+        validate_entity({"entity_kind": "invalid"})
+
+
+def test_validate_filename():
+    assert validate_filename("123") == "123"
+    with pytest.raises(ValidationError):
+        validate_filename("12a")
+
+
+def test_validate_analysis_type():
+    for atype in ALLOWED_ANALYSIS_TYPES:
+        assert validate_analysis_type(atype) == atype
+    with pytest.raises(ValidationError):
+        validate_analysis_type("unknown")

--- a/validators.py
+++ b/validators.py
@@ -1,0 +1,53 @@
+"""Проверки структур входных данных для анализа."""
+from __future__ import annotations
+from typing import Iterable
+
+class ValidationError(ValueError):
+    """Ошибка проверки входных данных."""
+
+
+ALLOWED_ANALYSIS_TYPES = {"static", "dynamic", "frequency"}
+
+
+def ensure_unique_names(items: Iterable, key: str = "name"):
+    """Проверяет, что имена объектов на одном уровне уникальны."""
+    names = [getattr(item, key, item.get(key) if isinstance(item, dict) else None) for item in items]
+    if None in names:
+        raise ValidationError("Объекты должны содержать поле имени")
+    if len(names) != len(set(names)):
+        raise ValidationError("Имена должны быть уникальны на одном уровне")
+    return items
+
+
+def validate_entity(data: dict):
+    """Проверяет корректность описания сущности."""
+    kind = data.get("entity_kind")
+    if kind not in {"element", "node"}:
+        raise ValidationError("entity_kind может быть только 'element' или 'node'")
+    if kind == "element" and not data.get("element_type"):
+        raise ValidationError("Для 'element' необходимо указать element_type")
+    return data
+
+
+def validate_filename(name: str):
+    """Имя файла должно состоять только из цифр."""
+    if not name.isdigit():
+        raise ValidationError("Имя файла должно содержать только цифры")
+    return name
+
+
+def validate_analysis_type(analysis_type: str):
+    """Проверяет тип анализа по реестру допустимых значений."""
+    if analysis_type not in ALLOWED_ANALYSIS_TYPES:
+        raise ValidationError("Недопустимый тип анализа")
+    return analysis_type
+
+
+__all__ = [
+    "ValidationError",
+    "ALLOWED_ANALYSIS_TYPES",
+    "ensure_unique_names",
+    "validate_entity",
+    "validate_filename",
+    "validate_analysis_type",
+]


### PR DESCRIPTION
## Summary
- Проверка уникальности имен на одном уровне
- Валидация entity_kind и обязательного element_type
- Ограничение имени файла цифрами и анализов по реестру допустимых типов

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab39452458832abe5891eedc2e65eb