### PR TITLE
feat: add analysis type enumeration

### DIFF
--- a/analysis_types.py
+++ b/analysis_types.py
@@ -1,0 +1,19 @@
+from enum import Enum
+
+class AnalysisType(str, Enum):
+    """Допустимые типы анализа."""
+    TIME_AXIAL_FORCE = "Время-Продольное усилие"
+    TIME_SHEAR_FORCE_QY = "Время-Поперечная сила QY"
+    TIME_SHEAR_FORCE_QZ = "Время-Поперечная сила QZ"
+    TIME_MOMENT_MX = "Время-Момент MX"
+    TIME_MOMENT_MY = "Время-Момент MY"
+    TIME_MOMENT_MZ = "Время-Момент MZ"
+
+    @classmethod
+    def list(cls) -> list[str]:
+        """Возвращает список строковых значений."""
+        return [item.value for item in cls]
+
+ANALYSIS_TYPES = AnalysisType.list()
+
+__all__ = ["AnalysisType", "ANALYSIS_TYPES"]

--- a/tabs/function_for_all_tabs/validation.py
+++ b/tabs/function_for_all_tabs/validation.py
@@ -27,6 +27,10 @@ class NotEnoughPointsError(ValidationError):
     """Недостаточно точек для операции."""
 
 
+class InvalidAnalysisTypeError(ValidationError):
+    """Недопустимый тип анализа."""
+
+
 def ensure_not_empty(seq, name: str = "данные"):
     """Гарантирует, что последовательность не пуста."""
     if not seq:
@@ -64,6 +68,15 @@ def ensure_min_length(data, min_len: int = 2, name: str = "точек"):
     return data
 
 
+def ensure_analysis_type(analysis_type: str):
+    """Проверяет, что тип анализа поддерживается."""
+    from analysis_types import ANALYSIS_TYPES  # локальный импорт для избежания циклов
+
+    if analysis_type not in ANALYSIS_TYPES:
+        raise InvalidAnalysisTypeError("Некорректный тип анализа")
+    return analysis_type
+
+
 __all__ = [
     "ValidationError",
     "EmptyDataError",
@@ -71,9 +84,11 @@ __all__ = [
     "SizeMismatchError",
     "ZeroStepError",
     "NotEnoughPointsError",
+    "InvalidAnalysisTypeError",
     "ensure_not_empty",
     "ensure_numbers",
     "ensure_same_length",
     "ensure_non_zero_step",
     "ensure_min_length",
+    "ensure_analysis_type",
 ]

--- a/tabs/functions_for_tab1/curves.py
+++ b/tabs/functions_for_tab1/curves.py
@@ -6,6 +6,7 @@ from widgets import create_text, select_path
 
 from .events import on_combobox_event, on_combo_change_curve_type
 from ui import constants as ui_const
+from analysis_types import ANALYSIS_TYPES
 
 
 def _build_source_section(axis: str, input_frame: tk.Widget, i: int, saved_data: list[dict]) -> Dict[str, Any]:
@@ -539,6 +540,19 @@ def create_curve_box(input_frame, i, checkbox_var, saved_data):
     )
     combo_curve_typeY_type._name = f"curve_{i}_typeYFtype"
 
+    label_analysis_type = ttk.Label(input_frame, text="Тип анализа:")
+    combo_analysis_type = ttk.Combobox(
+        input_frame, values=ANALYSIS_TYPES, state="readonly"
+    )
+    combo_analysis_type._name = f"curve_{i}_analysis_type"
+    saved_at = saved_data[i - 1].get("analysis_type")
+    if saved_at:
+        combo_analysis_type.set(saved_at)
+    combo_analysis_type.bind(
+        "<<ComboboxSelected>>",
+        lambda e: saved_data[i - 1].update({"analysis_type": combo_analysis_type.get()}),
+    )
+
     x_source = _build_source_section("X", input_frame, i, saved_data)
     y_source = _build_source_section("Y", input_frame, i, saved_data)
 
@@ -573,6 +587,8 @@ def create_curve_box(input_frame, i, checkbox_var, saved_data):
                 paths["label_path_Y"],
                 paths["path_entry_Y"],
                 paths["select_button_Y"],
+                label_analysis_type,
+                combo_analysis_type,
             )
         for w in [
             options["label_param"],
@@ -692,6 +708,8 @@ def create_curve_box(input_frame, i, checkbox_var, saved_data):
                 paths["label_path_Y"],
                 paths["path_entry_Y"],
                 paths["select_button_Y"],
+                label_analysis_type,
+                combo_analysis_type,
             ),
             lambda e: saved_data[i - 1].update({"curve_type": combo_curve_type.get()}),
             lambda e: toggle_excel_options(),
@@ -745,6 +763,8 @@ def create_curve_box(input_frame, i, checkbox_var, saved_data):
         paths["label_path_Y"],
         paths["path_entry_Y"],
         paths["select_button_Y"],
+        label_analysis_type,
+        combo_analysis_type,
     )
     toggle_X_source_options()
     toggle_Y_source_options()
@@ -774,7 +794,7 @@ def update_curves(frame, num_curves, next_frame, checkbox_var, saved_data):
     # Восстанавливаем данные, если они есть
     for i in range(len(saved_data), num_curves_int):
         saved_data.append({'curve_type': "", 'path': "", 'legend': "", 'curve_typeX': "", 'curve_typeY': "",
-                           'curve_typeX_type': "", 'curve_typeY_type': "", 'horizontal': False,
+                           'curve_typeX_type': "", 'curve_typeY_type': "", 'analysis_type': "", 'horizontal': False,
                            'use_offset': False, 'offset_horizontal': 0, 'offset_vertical': 0,
                            'use_ranges': False, 'range_x': '', 'range_y': '',
                            'X_source': {}, 'Y_source': {}})

--- a/tabs/functions_for_tab1/events.py
+++ b/tabs/functions_for_tab1/events.py
@@ -11,13 +11,33 @@ def on_combobox_event(event, *callbacks):
                 callback()
 
 
-def on_combo_change_curve_type(frame, combo, label_curve_typeX, combo_curve_typeX, label_curve_typeY, combo_curve_typeY,
-                               label_curve_typeX_type, combo_curve_typeX_type, label_curve_typeY_type,
-                               combo_curve_typeY_type, label_source_X, combo_source_X,
-                               label_source_Y, combo_source_Y,
-                               label_path, path_entry, select_button,
-                               label_path_X, path_entry_X, select_button_X,
-                               label_path_Y, path_entry_Y, select_button_Y):
+def on_combo_change_curve_type(
+    frame,
+    combo,
+    label_curve_typeX,
+    combo_curve_typeX,
+    label_curve_typeY,
+    combo_curve_typeY,
+    label_curve_typeX_type,
+    combo_curve_typeX_type,
+    label_curve_typeY_type,
+    combo_curve_typeY_type,
+    label_source_X,
+    combo_source_X,
+    label_source_Y,
+    combo_source_Y,
+    label_path,
+    path_entry,
+    select_button,
+    label_path_X,
+    path_entry_X,
+    select_button_X,
+    label_path_Y,
+    path_entry_Y,
+    select_button_Y,
+    label_analysis_type,
+    combo_analysis_type,
+):
     def _init_geom(widget):
         if not hasattr(widget, "_orig_geom"):
             frame.update_idletasks()
@@ -67,6 +87,8 @@ def on_combo_change_curve_type(frame, combo, label_curve_typeX, combo_curve_type
         label_path_Y.place_forget()
         path_entry_Y.place_forget()
         select_button_Y.place_forget()
+        label_analysis_type.place_forget()
+        combo_analysis_type.place_forget()
     elif combo.get() == "Комбинированный":
         label_curve_typeX.place_forget()
         combo_curve_typeX.place_forget()
@@ -108,6 +130,34 @@ def on_combo_change_curve_type(frame, combo, label_curve_typeX, combo_curve_type
         label_path_Y.place(x=base_x, y=base_y_label + 50)
         path_entry_Y.place(x=base_x, y=base_y_entry + 50, width=width)
         select_button_Y.place(x=button_x, y=base_y_button + 50)
+        label_analysis_type.place_forget()
+        combo_analysis_type.place_forget()
+    elif combo.get() == "Файл кривой LS-Dyna":
+        label_curve_typeX.place_forget()
+        combo_curve_typeX.place_forget()
+        label_curve_typeY.place_forget()
+        combo_curve_typeY.place_forget()
+        label_curve_typeX_type.place_forget()
+        combo_curve_typeX_type.place_forget()
+        label_curve_typeY_type.place_forget()
+        combo_curve_typeY_type.place_forget()
+        label_source_X.place_forget()
+        combo_source_X.place_forget()
+        label_source_Y.place_forget()
+        combo_source_Y.place_forget()
+
+        label_path.place(x=label_path_geom["x"], y=label_path_geom["y"])
+        path_entry.place(x=path_entry_geom["x"], y=path_entry_geom["y"], width=path_entry_geom["w"])
+        select_button.place(x=select_button_geom["x"], y=select_button_geom["y"])
+        label_path_X.place_forget()
+        path_entry_X.place_forget()
+        select_button_X.place_forget()
+        label_path_Y.place_forget()
+        path_entry_Y.place_forget()
+        select_button_Y.place_forget()
+
+        label_analysis_type.place(x=combo.winfo_x() + 170, y=combo.winfo_y() - 20)
+        combo_analysis_type.place(x=combo.winfo_x() + 170, y=combo.winfo_y(), width=150)
     else:
         label_curve_typeX.place_forget()
         combo_curve_typeX.place_forget()
@@ -131,3 +181,5 @@ def on_combo_change_curve_type(frame, combo, label_curve_typeX, combo_curve_type
         label_path_Y.place_forget()
         path_entry_Y.place_forget()
         select_button_Y.place_forget()
+        label_analysis_type.place_forget()
+        combo_analysis_type.place_forget()

--- a/tabs/functions_for_tab1/plotting.py
+++ b/tabs/functions_for_tab1/plotting.py
@@ -19,6 +19,7 @@ from tabs.constants import (
     LEGEND_TITLE_TRANSLATIONS,
 )
 from tabs.title_utils import format_signature
+from tabs.function_for_all_tabs.validation import ensure_analysis_type, InvalidAnalysisTypeError
 
 logger = logging.getLogger(__name__)
 
@@ -312,6 +313,8 @@ def generate_graph(
                     curve_info.setdefault("Y_source", {}).update(
                         {"curve_file": widget.get()}
                     )
+                elif widget_name == f"curve_{i}_analysis_type":
+                    curve_info["analysis_type"] = widget.get()
 
                 if widget_name == f"curve_{i}_horizontal":
                     curve_info["horizontal"] = widget.var.get()
@@ -369,6 +372,12 @@ def generate_graph(
             if not Path(file).exists():
                 messagebox.showerror("Ошибка", f"Файл {file} не найден")
                 return
+            if curve_info.get("curve_type") == "Файл кривой LS-Dyna":
+                try:
+                    ensure_analysis_type(curve_info.get("analysis_type", ""))
+                except InvalidAnalysisTypeError:
+                    messagebox.showerror("Ошибка", f"Некорректный тип анализа для кривой {i}")
+                    return
 
         # Добавляем информацию о кривой в общий список
         if "X_source" in curve_info and "column" not in curve_info["X_source"]:

--- a/tests/test_analysis_type_validator.py
+++ b/tests/test_analysis_type_validator.py
@@ -1,0 +1,16 @@
+import pytest
+
+from analysis_types import AnalysisType
+from tabs.function_for_all_tabs.validation import (
+    ensure_analysis_type,
+    InvalidAnalysisTypeError,
+)
+
+
+def test_ensure_analysis_type_valid():
+    assert ensure_analysis_type(AnalysisType.TIME_AXIAL_FORCE.value) == AnalysisType.TIME_AXIAL_FORCE.value
+
+
+def test_ensure_analysis_type_invalid():
+    with pytest.raises(InvalidAnalysisTypeError):
+        ensure_analysis_type("неизвестный тип")


### PR DESCRIPTION
## Summary
- add enum for supported analysis types
- validate analysis type in LS-Dyna curves and GUI
- cover analysis type validator with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab39560edc832ab43e9859e4f80783