### PR TITLE
Add curve command builder

### DIFF
--- a/tabs/function4tabs4/command_single.py
+++ b/tabs/function4tabs4/command_single.py
@@ -2,9 +2,35 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Tuple
+from pathlib import PureWindowsPath
 
 from .naming import safe_name
+
+
+# Шаблоны выбора сущности в LS-PrePost.
+# Ключем служит кортеж (entity_kind, element_type).
+SELECT_TEMPLATES: Dict[Tuple[str, str | None], List[str]] = {
+    ("element", "beam"): [
+        "genselect clear all",
+        "genselect beam add beam {element_id}/0",
+        "etype 1 ;etime 4",
+    ],
+    ("element", "shell"): [
+        "genselect clear all",
+        "genselect shell add shell {element_id}/0",
+        "etype 1 ;etime 4",
+    ],
+    ("element", "solid"): [
+        "genselect clear all",
+        "genselect solid add solid {element_id}/0",
+        "etype 1 ;etime 4",
+    ],
+    ("node", None): [
+        "genselect clear all",
+        "genselect node add node {element_id}",
+    ],
+}
 
 
 def build_command(name: str, props: Dict[str, Any]) -> str:
@@ -14,4 +40,56 @@ def build_command(name: str, props: Dict[str, Any]) -> str:
     return " ".join([safe] + parts)
 
 
-__all__ = ["build_command"]
+def build_curve_commands(
+    base_project_dir: str,
+    top_folder_name: str,
+    analysis_type: str,
+    entity_kind: str,
+    element_type: str | None,
+    element_id: int,
+    curves_dirname: str = "curves",
+) -> List[str]:
+    """Построить последовательность команд для сохранения кривой.
+
+    Возвращает список строк без символов перевода строки.
+    """
+
+    if not analysis_type:
+        raise ValueError("analysis_type must be non-empty")
+    if element_id <= 0:
+        raise ValueError("element_id must be positive")
+    if entity_kind not in {"element", "node"}:
+        raise ValueError("unknown entity_kind")
+    if entity_kind == "element":
+        if element_type not in {"beam", "shell", "solid"}:
+            raise ValueError("invalid element_type for element")
+    else:
+        if element_type is not None:
+            raise ValueError("element_type must be None for node")
+
+    key = (entity_kind, element_type)
+    try:
+        template = SELECT_TEMPLATES[key]
+    except KeyError as exc:  # pragma: no cover - should not happen after validation
+        raise ValueError("unsupported entity selection") from exc
+
+    select_cmds = [cmd.format(element_id=element_id) for cmd in template]
+
+    curve_path = PureWindowsPath(
+        base_project_dir,
+        curves_dirname,
+        top_folder_name,
+        analysis_type,
+        f"{element_id}.txt",
+    )
+
+    save_cmds = [
+        f'xyplot 1 savefile curve_file "{curve_path}" 1 all',
+        "xyplot 1 donemenu",
+        "deletewin 1",
+    ]
+
+    return select_cmds + save_cmds
+
+
+__all__ = ["build_command", "build_curve_commands"]


### PR DESCRIPTION
## Summary
- add templates for LS-PrePost entity selection
- implement build_curve_commands to generate command sequences for saving curves

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab3b8d1c0c832aafadefaf5198bf99