### PR TITLE
Добавить подпапку анализа из списка

### DIFF
--- a/tests/test_entitynode_add_analysis.py
+++ b/tests/test_entitynode_add_analysis.py
@@ -1,0 +1,24 @@
+import pytest
+
+from analysis_types import AnalysisType
+from tree_schema import EntityNode
+
+
+def test_add_analysis_valid():
+    node = EntityNode(user_name="user", entity_kind="node")
+    analysis = node.add_analysis(AnalysisType.TIME_AXIAL_FORCE.value)
+    assert analysis in node.children
+    assert analysis.analysis_type == AnalysisType.TIME_AXIAL_FORCE.value
+
+
+def test_add_analysis_invalid():
+    node = EntityNode(user_name="user", entity_kind="node")
+    with pytest.raises(ValueError):
+        node.add_analysis("неизвестный тип")
+
+
+def test_add_analysis_duplicate():
+    node = EntityNode(user_name="user", entity_kind="node")
+    node.add_analysis(AnalysisType.TIME_AXIAL_FORCE.value)
+    with pytest.raises(ValueError):
+        node.add_analysis(AnalysisType.TIME_AXIAL_FORCE.value)

--- a/tree_schema.py
+++ b/tree_schema.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
+from analysis_types import ANALYSIS_TYPES
+
 EntityKind = Literal["element", "node"]
 ElementType = Literal["beam", "shell", "solid"]
 
@@ -50,6 +52,35 @@ class EntityNode:
     entity_kind: EntityKind
     element_type: ElementType | None = None
     children: list[AnalysisNode] = field(default_factory=list)
+
+    def add_analysis(self, analysis_type: str) -> AnalysisNode:
+        """Добавляет подпапку анализа к узлу.
+
+        Parameters
+        ----------
+        analysis_type: str
+            Название анализа, выбранное из ``analysis_types.ANALYSIS_TYPES``.
+
+        Returns
+        -------
+        AnalysisNode
+            Созданный узел анализа.
+
+        Raises
+        ------
+        ValueError
+            Если тип анализа недопустим или уже существует.
+        """
+
+        if analysis_type not in ANALYSIS_TYPES:
+            raise ValueError("Недопустимый тип анализа")
+
+        if any(ch.analysis_type == analysis_type for ch in self.children):
+            raise ValueError("Анализ уже добавлен")
+
+        node = AnalysisNode(analysis_type=analysis_type)
+        self.children.append(node)
+        return node
 
     def to_dict(self) -> dict:
         data = {


### PR DESCRIPTION
## Summary
- Добавлен метод `add_analysis` в `EntityNode` для создания подпапок анализа только из допустимых типов
- Добавлены тесты на корректное добавление и обработку ошибок

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab3d9e4b40832a9c6a7d0a7d783d5d