### PR TITLE
Диалог числового ввода для анализа

### DIFF
--- a/tabs/tab4.py
+++ b/tabs/tab4.py
@@ -1,4 +1,7 @@
+import tkinter as tk
 from tkinter import ttk
+
+from widgets import ask_numeric_id
 
 
 def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:
@@ -6,4 +9,22 @@ def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:
 
     tab4 = ttk.Frame(notebook)
     notebook.add(tab4, text="Вкладка 4")
+
+    tree = ttk.Treeview(tab4)
+    tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+    entity = tree.insert("", "end", text="Сущность", open=True)
+    analysis = tree.insert(entity, "end", text="Анализ", open=True)
+
+    def add_file_node():
+        selected = tree.selection()
+        if not selected or selected[0] != analysis:
+            return
+        number = ask_numeric_id(tab4, title="Номер элемента/узла")
+        if number is not None:
+            tree.insert(analysis, "end", text=str(number))
+
+    add_btn = ttk.Button(tab4, text="+", command=add_file_node)
+    add_btn.pack(side=tk.LEFT, padx=5, pady=5)
+
     return tab4

--- a/widgets/__init__.py
+++ b/widgets/__init__.py
@@ -6,6 +6,7 @@ from .select_path import select_path
 from .message_log import message_log
 from .text_widget import create_text, clear_text
 from .plot_editor import PlotEditor
+from .numeric_id_dialog import ask_numeric_id
 
 __all__ = [
     "make_context_menu",
@@ -15,5 +16,6 @@ __all__ = [
     "create_text",
     "clear_text",
     "PlotEditor",
+    "ask_numeric_id",
 ]
 

--- a/widgets/numeric_id_dialog.py
+++ b/widgets/numeric_id_dialog.py
@@ -1,0 +1,38 @@
+import tkinter as tk
+from tkinter import simpledialog
+
+
+class NumericIDDialog(simpledialog.Dialog):
+    """Диалог ввода числового идентификатора."""
+
+    def body(self, master):
+        tk.Label(master, text="Номер элемента/узла:").grid(row=0, column=0, padx=5, pady=5)
+        self.var = tk.StringVar()
+        vcmd = master.register(self._on_validate)
+        self.entry = tk.Entry(master, textvariable=self.var, validate="key", validatecommand=(vcmd, "%P"))
+        self.entry.grid(row=0, column=1, padx=5, pady=5)
+        return self.entry
+
+    def _on_validate(self, new_value: str) -> bool:
+        """Позволяет вводить только цифры."""
+        if new_value.isdigit() or new_value == "":
+            self.entry.config(bg="white")
+            return True
+        self.entry.config(bg="#ffdddd")
+        return False
+
+    def validate(self) -> bool:  # type: ignore[override]
+        value = self.var.get()
+        if not value.isdigit():
+            self.entry.config(bg="#ffdddd")
+            return False
+        return True
+
+    def apply(self) -> None:  # type: ignore[override]
+        self.result = int(self.var.get())
+
+
+def ask_numeric_id(parent, title: str = "Введите номер"):
+    """Запросить у пользователя числовой идентификатор."""
+    dialog = NumericIDDialog(parent, title)
+    return dialog.result


### PR DESCRIPTION
## Summary
- добавлен диалог для ввода номера элемента/узла с проверкой на цифры
- кнопка `+` на вкладке анализа открывает диалог и добавляет номер в дерево

## Testing
- `pytest`
- `ruff check .` *(известные ошибки в существующем коде)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3da47994832abdaf512c651a85df