### PR TITLE
Ensure top folder names recalculated on tree load

### DIFF
--- a/tabs/function4tabs4/tree_io.py
+++ b/tabs/function4tabs4/tree_io.py
@@ -4,23 +4,27 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable, List
 
-from .tree_schema import Tree
+from tree_schema import EntityNode
 
 
-def save_tree(tree: Tree, path: str | Path) -> Path:
+def save_tree(tree: Iterable[EntityNode], path: str | Path) -> Path:
     """Сохранить ``tree`` в JSON файл ``path``."""
     dest = Path(path)
-    dest.write_text(json.dumps(tree.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8")
+    data = [node.to_dict() for node in tree]
+    dest.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
     return dest
 
 
-def load_tree(path: str | Path) -> Tree:
+def load_tree(path: str | Path) -> List[EntityNode]:
     """Загрузить дерево из JSON файла."""
     src = Path(path)
     data: Any = json.loads(src.read_text(encoding="utf-8"))
-    return Tree.from_dict(data)
+    nodes = [EntityNode.from_dict(d) for d in data]
+    for node in nodes:  # Пересчитываем имя папки верхнего уровня
+        node.recalc_top_folder_name()
+    return nodes
 
 
 __all__ = ["save_tree", "load_tree"]

--- a/tree_schema.py
+++ b/tree_schema.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
+from topfolder_codec import encode_topfolder
+
 EntityKind = Literal["element", "node"]
 ElementType = Literal["beam", "shell", "solid"]
 
@@ -50,6 +52,16 @@ class EntityNode:
     entity_kind: EntityKind
     element_type: ElementType | None = None
     children: list[AnalysisNode] = field(default_factory=list)
+    top_folder_name: str = field(init=False)
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple assignment
+        self.recalc_top_folder_name()
+
+    def recalc_top_folder_name(self) -> None:
+        """Recalculate and store encoded top folder name."""
+        self.top_folder_name = encode_topfolder(
+            self.user_name, self.entity_kind, self.element_type
+        )
 
     def to_dict(self) -> dict:
         data = {


### PR DESCRIPTION
## Summary
- compute and store `top_folder_name` for each entity node
- reload trees via `tree_io` and recalc top folder names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab3db6fd8c832aba5634c459ea8e46