### PR TITLE
Связка формирования графиков с генерацией отчёта

### DIFF
--- a/curves_pipeline.py
+++ b/curves_pipeline.py
@@ -1,0 +1,59 @@
+"""Рабочий процесс генерации графиков и отчёта."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
+from curves_scan import scan_curves
+from plot_from_txt import plot_from_txt
+
+try:  # pragma: no cover - зависимость может отсутствовать
+    from report_docx import build_report
+except Exception:  # noqa: BLE001 - перехват любых ошибок импорта
+    build_report = None  # type: ignore[assignment]
+
+
+def build_curves_report(curves_root: Path | str) -> Tuple[Path | None, List[str]]:
+    """Сканирует каталоги, строит PNG и формирует DOCX.
+
+    Параметры:
+        curves_root: Корневая папка, содержащая топ-папки с анализами.
+
+    Возвращает:
+        Кортеж ``(путь к Report.docx или None, список ошибок)``.
+    """
+    root = Path(curves_root)
+    errors: List[str] = []
+
+    try:
+        structure = scan_curves(root)
+    except Exception as exc:  # pragma: no cover - защитный код
+        errors.append(f"Сканирование: {exc}")
+        structure = {}
+
+    for analyses in structure.values():
+        for analysis_type, files in analyses.items():
+            existing_pngs = {Path(f) for f in files if f.lower().endswith(".png")}
+            for txt_file in (Path(f) for f in files if f.lower().endswith(".txt")):
+                png_file = txt_file.with_suffix(".png")
+                if png_file not in existing_pngs:
+                    try:
+                        plot_from_txt(str(txt_file), analysis_type, str(png_file))
+                        existing_pngs.add(png_file)
+                    except Exception as exc:  # pragma: no cover - отсутствие GUI
+                        errors.append(f"{txt_file}: {exc}")
+
+    docx_path: Path | None = None
+    if build_report is None:
+        errors.append("DOCX: модуль python-docx недоступен")
+    else:
+        try:
+            docx_path = build_report(root)
+        except Exception as exc:  # pragma: no cover - защитный код
+            errors.append(f"DOCX: {exc}")
+
+    return docx_path, errors
+
+
+__all__ = ["build_curves_report"]

--- a/tabs/tab4.py
+++ b/tabs/tab4.py
@@ -16,6 +16,7 @@ from tabs.function4tabs4.tree_io import load_tree, save_tree
 from topfolder_codec import decode_topfolder, encode_topfolder
 from ui import constants as ui_const
 from widgets import create_text, select_path
+from curves_pipeline import build_curves_report
 
 
 class NumberInputDialog(simpledialog.Dialog):
@@ -287,7 +288,27 @@ def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:
         if not path:
             messagebox.showerror("Ошибка", "Укажите папку для кривых", parent=tab4)
             return
-        messagebox.showinfo("Готово", f"Графики сформированы в {path}", parent=tab4)
+
+        root = Path(path)
+        if not root.exists():
+            messagebox.showerror("Ошибка", f"Папка {path} не найдена", parent=tab4)
+            return
+
+        docx_path, errors = build_curves_report(root)
+        if errors:
+            error_file = root / "errors.log"
+            error_file.write_text("\n".join(errors), encoding="utf-8")
+            messagebox.showwarning(
+                "Готово с ошибками",
+                f"Возникли ошибки. См. {error_file}",
+                parent=tab4,
+            )
+        else:
+            messagebox.showinfo(
+                "Готово",
+                f"Отчёт сформирован: {docx_path}",
+                parent=tab4,
+            )
 
     # --- Панель кнопок ---
     btn_frame = ttk.Frame(tab4)

--- a/tests/test_curves_process.py
+++ b/tests/test_curves_process.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from unittest.mock import patch
+import importlib.util
+import pytest
+
+from analysis_types import AnalysisType
+from curves_pipeline import build_curves_report
+from PIL import Image
+
+if importlib.util.find_spec("docx") is None:
+    pytest.skip("python-docx не установлен", allow_module_level=True)
+
+
+def _fake_create_plot(curves_info, x_label, y_label, title, save_file, file_plt, **kwargs):
+    Image.new("RGB", (1, 1), color="white").save(file_plt)
+
+
+def test_build_curves_report(tmp_path):
+    top = tmp_path / "Top"
+    analysis_dir = top / AnalysisType.TIME_AXIAL_FORCE.value
+    analysis_dir.mkdir(parents=True)
+    txt_file = analysis_dir / "curve.txt"
+    txt_file.write_text("0 0\n1 1\n", encoding="utf-8")
+
+    with patch("plot_from_txt.create_plot", side_effect=_fake_create_plot):
+        docx_path, errors = build_curves_report(tmp_path)
+
+    assert not errors
+    assert (analysis_dir / "curve.png").exists()
+    assert docx_path is not None and docx_path.exists()


### PR DESCRIPTION
## Summary
- Добавлен модуль `curves_pipeline` для сканирования, построения PNG и сборки DOCX с отчётом об ошибках
- Кнопка `Сформировать графики` запускает полный процесс и сохраняет ошибки в `errors.log`
- Добавлен тест процесса формирования графиков

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab51ff63f8832a985ece315f31c2e7