### PR TITLE
feat: support multiple top folders

### DIFF
--- a/tests/test_tab4_top_nodes.py
+++ b/tests/test_tab4_top_nodes.py
@@ -1,0 +1,36 @@
+import pytest
+import tkinter as tk
+from tkinter import ttk
+
+import tabs.tab4 as tab4mod
+from tabs.tab4 import create_tab4
+
+
+def _create_app():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tkinter requires a display")
+    root.withdraw()
+    nb = ttk.Notebook(root)
+    tab = create_tab4(nb)
+    return root, tab
+
+
+def test_add_rename_remove_top_nodes(monkeypatch):
+    root, tab = _create_app()
+    tree = tab.tree
+
+    start = len(tree.get_children())
+    tab.add_node()
+    assert len(tree.get_children()) == start + 1
+
+    new_item = tree.get_children()[-1]
+    tree.selection_set(new_item)
+    monkeypatch.setattr(tab4mod.simpledialog, "askstring", lambda *a, **k: "Renamed")
+    tab.rename_node()
+    assert tree.item(new_item, "text") == "Renamed"
+
+    tab.remove_node()
+    assert len(tree.get_children()) == start
+    root.destroy()


### PR DESCRIPTION
## Summary
- allow adding multiple top-level folders by using hidden root
- update tree operations and context menu for multi-root support
- cover adding, renaming and removing top folders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab5c979530832aa6b049c1e5d28082