### PR TITLE
Добавлен выбор типа анализа в четвёртой вкладке

### DIFF
--- a/tests/test_tab4_analysis_dialog.py
+++ b/tests/test_tab4_analysis_dialog.py
@@ -1,0 +1,36 @@
+import pytest
+import tkinter as tk
+from tkinter import ttk
+
+import tabs.tab4 as tab4mod
+from tabs.tab4 import create_tab4
+from analysis_types import ANALYSIS_TYPES
+
+
+def _create_app():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tkinter requires a display")
+    root.withdraw()
+    nb = ttk.Notebook(root)
+    tab = create_tab4(nb)
+    return root, tab
+
+
+def test_add_analysis_type(monkeypatch):
+    root, tab = _create_app()
+    tree = tab.tree
+    parent = tree.get_children()[0]
+    tree.selection_set(parent)
+    choice = ANALYSIS_TYPES[0]
+
+    class DummyDialog:
+        def __init__(self, *a, **k):
+            self.result = choice
+
+    monkeypatch.setattr(tab4mod, "AnalysisTypeDialog", DummyDialog)
+    tab.add_node()
+    child = tree.get_children(parent)[-1]
+    assert tree.item(child, "text") == choice
+    root.destroy()


### PR DESCRIPTION
## Summary
- заменить ввод номера элемента/узла на диалог выбора типа анализа
- добавить тест для вставки выбранного типа

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab5e092fdc832a942723c651f00acd