### PR TITLE
Расширение добавления узлов в дереве

### DIFF
--- a/tests/test_tab4_analysis_dialog.py
+++ b/tests/test_tab4_analysis_dialog.py
@@ -21,7 +21,7 @@ def _create_app():
 def test_add_analysis_type(monkeypatch):
     root, tab = _create_app()
     tree = tab.tree
-    parent = tree.get_children()[0]
+    parent = tree.insert("", "end", text="top")
     tree.selection_set(parent)
     choice = ANALYSIS_TYPES[0]
 
@@ -33,4 +33,26 @@ def test_add_analysis_type(monkeypatch):
     tab.add_node()
     child = tree.get_children(parent)[-1]
     assert tree.item(child, "text") == choice
+    root.destroy()
+
+
+def test_add_element_number(monkeypatch):
+    root, tab = _create_app()
+    tree = tab.tree
+    top = tree.insert("", "end", text="top")
+    tree.selection_set(top)
+    choice = ANALYSIS_TYPES[0]
+
+    class DummyDialog:
+        def __init__(self, *a, **k):
+            self.result = choice
+
+    monkeypatch.setattr(tab4mod, "AnalysisTypeDialog", DummyDialog)
+    tab.add_node()
+    analysis = tree.get_children(top)[-1]
+    tree.selection_set(analysis)
+    monkeypatch.setattr(tab4mod.simpledialog, "askstring", lambda *a, **k: "15")
+    tab.add_node()
+    child = tree.get_children(analysis)[-1]
+    assert tree.item(child, "text") == "15"
     root.destroy()

--- a/tests/test_tab4_top_nodes.py
+++ b/tests/test_tab4_top_nodes.py
@@ -22,12 +22,22 @@ def test_add_rename_remove_top_nodes(monkeypatch):
     tree = tab.tree
 
     start = len(tree.get_children())
+
+    class DummySectionDialog:
+        def __init__(self, _parent, tree_widget, item=None):
+            if item:
+                tree_widget.item(item, text="Renamed")
+            else:
+                tree_widget.insert("", "end", text="Added")
+            self.result = "ok"
+
+    monkeypatch.setattr(tab4mod, "SectionDialog", DummySectionDialog)
+
     tab.add_node()
     assert len(tree.get_children()) == start + 1
 
     new_item = tree.get_children()[-1]
     tree.selection_set(new_item)
-    monkeypatch.setattr(tab4mod.simpledialog, "askstring", lambda *a, **k: "Renamed")
     tab.rename_node()
     assert tree.item(new_item, "text") == "Renamed"
 


### PR DESCRIPTION
## Summary
- Реализована многоуровневая логика `add_node` в табе 4
- Обновлено контекстное меню и добавлены горячие клавиши
- Добавлены тесты для новых сценариев добавления

## Testing
- `pytest tests/test_tab4_top_nodes.py tests/test_tab4_analysis_dialog.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab664456c4832aa361f98b2c261302