### PR TITLE
Поддержка кириллицы в safe_name

### DIFF
--- a/tabs/function4tabs4/naming.py
+++ b/tabs/function4tabs4/naming.py
@@ -6,7 +6,7 @@ import re
 from pathlib import Path
 from typing import Iterable
 
-_SAFE_CHARS_RE = re.compile(r"[^A-Za-z0-9_.\-]")
+_SAFE_CHARS_RE = re.compile(r"[^A-Za-z0-9_.\-А-Яа-яЁё]")
 
 
 def safe_name(name: str, replacement: str = "_") -> str:

--- a/tests/test_tabs_naming.py
+++ b/tests/test_tabs_naming.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import pytest
 from tabs.function4tabs4.naming import safe_name, join_path
 
 
@@ -7,3 +8,8 @@ def test_safe_name_and_join_path(tmp_path):
     assert safe_name("") == "untitled"
     path = join_path(tmp_path, "a/b", "c:d")
     assert path == tmp_path / "a_b" / "c_d"
+
+
+@pytest.mark.parametrize("name", ["Колонна", "Плита", "Стена", "Балка"])
+def test_safe_name_cyrillic_words(name):
+    assert safe_name(name) == name


### PR DESCRIPTION
## Summary
- разрешены кириллические буквы в `safe_name`
- добавлены тесты для слов «Колонна», «Плита», «Стена», «Балка»

## Testing
- `pytest tests/test_tabs_naming.py tests/test_command_all.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab6ba37d10832a86af83c26bb99b77