### PR TITLE
Добавлен диалог сохранения C-файла

### DIFF
--- a/tabs/tab4.py
+++ b/tabs/tab4.py
@@ -409,7 +409,9 @@ def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:
     cfile_entry = create_text(cfile_frame, method="entry", state="normal")
     cfile_entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
     ttk.Button(
-        cfile_frame, text="Обзор", command=lambda: select_path(cfile_entry, "file")
+        cfile_frame,
+        text="Обзор",
+        command=lambda: select_path(cfile_entry, "save_file"),
     ).pack(side=tk.LEFT, padx=5)
     ttk.Button(
         cfile_frame, text="Сформировать C-файл", command=generate_cfile

--- a/widgets/__init__.py
+++ b/widgets/__init__.py
@@ -6,7 +6,7 @@ from .select_path import select_path
 from .message_log import message_log
 from .text_widget import create_text, clear_text
 from .plot_editor import PlotEditor
-from .dialogs import ask_directory, ask_file, show_error
+from .dialogs import ask_directory, ask_file, ask_save_file, show_error
 
 __all__ = [
     "make_context_menu",
@@ -18,6 +18,7 @@ __all__ = [
     "PlotEditor",
     "ask_directory",
     "ask_file",
+    "ask_save_file",
     "show_error",
 ]
 

--- a/widgets/dialogs.py
+++ b/widgets/dialogs.py
@@ -12,6 +12,14 @@ def ask_file() -> str:
     return path
 
 
+def ask_save_file() -> str:
+    """Открывает диалог сохранения файла."""
+    path = filedialog.asksaveasfilename()
+    if not path:
+        logger.info("Файл не выбран")
+    return path
+
+
 def ask_directory() -> str:
     """Открывает диалог выбора папки."""
     path = filedialog.askdirectory()

--- a/widgets/select_path.py
+++ b/widgets/select_path.py
@@ -1,6 +1,6 @@
 import tkinter as tk
 
-from .dialogs import ask_directory, ask_file
+from .dialogs import ask_directory, ask_file, ask_save_file
 
 
 def select_path(entry_widget, path_type="folder", saved_data=None):
@@ -9,8 +9,10 @@ def select_path(entry_widget, path_type="folder", saved_data=None):
         selected_path = ask_directory()
     elif path_type == "file":
         selected_path = ask_file()
+    elif path_type == "save_file":
+        selected_path = ask_save_file()
     else:
-        raise ValueError("Недопустимый тип пути: используйте 'folder' или 'file'.")
+        raise ValueError("Недопустимый тип пути: используйте 'folder', 'file' или 'save_file'.")
 
     if selected_path:
         entry_widget.delete(0, tk.END)


### PR DESCRIPTION
### Изменения
- добавлен `ask_save_file` для сохранения путей
- поддержан тип пути `save_file` в `select_path`
- кнопка выбора C-файла теперь открывает диалог сохранения
- экспорт `ask_save_file` из пакета `widgets`

### Тестирование
- `python main.py` (окно закрыто)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab6d6680a8832abd05595972a8607f