### PR TITLE
Принудительное добавление расширения .cfile при сохранении

### DIFF
--- a/tabs/tab4.py
+++ b/tabs/tab4.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from gui_bridge import tree_from_gui
 from tabs.function4tabs4.cfile_writer import write_cfile
 from tabs.function4tabs4.command_all import walk_tree_and_build_commands
+from tabs.function4tabs4.config import CFILE_NAME
 from tabs.function4tabs4.naming import safe_name
 from tabs.function4tabs4.tree_schema import Tree
 from topfolder_codec import decode_topfolder, encode_topfolder
@@ -411,7 +412,7 @@ def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:
     ttk.Button(
         cfile_frame,
         text="Обзор",
-        command=lambda: select_path(cfile_entry, "save_file"),
+        command=lambda: select_path(cfile_entry, "save_file", extension=CFILE_NAME),
     ).pack(side=tk.LEFT, padx=5)
     ttk.Button(
         cfile_frame, text="Сформировать C-файл", command=generate_cfile

--- a/tests/test_cfile_extension.py
+++ b/tests/test_cfile_extension.py
@@ -1,0 +1,24 @@
+import tkinter as tk
+import pytest
+
+from widgets import select_path
+import widgets.dialogs as dialogs
+
+
+def test_select_path_appends_cfile_extension(monkeypatch):
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tkinter requires a display")
+    root.withdraw()
+    entry = tk.Entry(root)
+
+    monkeypatch.setattr(
+        dialogs.filedialog, "asksaveasfilename", lambda **_: "/tmp/test"
+    )
+
+    select_path(entry, "save_file", extension=".cfile")
+    assert entry.get() == "/tmp/test.cfile"
+
+    root.destroy()
+

--- a/widgets/dialogs.py
+++ b/widgets/dialogs.py
@@ -1,5 +1,6 @@
 from tkinter import filedialog, messagebox
 from logging_utils import get_logger
+from typing import Sequence
 
 logger = get_logger(__name__)
 
@@ -12,11 +13,19 @@ def ask_file() -> str:
     return path
 
 
-def ask_save_file() -> str:
+def ask_save_file(
+    defaultextension: str = "",
+    filetypes: Sequence[tuple[str, str]] | None = None,
+) -> str:
     """Открывает диалог сохранения файла."""
-    path = filedialog.asksaveasfilename()
+    path = filedialog.asksaveasfilename(
+        defaultextension=defaultextension,
+        filetypes=filetypes,
+    )
     if not path:
         logger.info("Файл не выбран")
+    elif defaultextension and not path.endswith(defaultextension):
+        path += defaultextension
     return path
 
 

--- a/widgets/select_path.py
+++ b/widgets/select_path.py
@@ -3,16 +3,26 @@ import tkinter as tk
 from .dialogs import ask_directory, ask_file, ask_save_file
 
 
-def select_path(entry_widget, path_type="folder", saved_data=None):
+def select_path(
+    entry_widget,
+    path_type="folder",
+    saved_data=None,
+    extension: str | None = None,
+):
     """Открывает диалог выбора пути и вставляет его в виджет."""
     if path_type == "folder":
         selected_path = ask_directory()
     elif path_type == "file":
         selected_path = ask_file()
     elif path_type == "save_file":
-        selected_path = ask_save_file()
+        filetypes = None
+        if extension:
+            filetypes = [(extension.lstrip("."), f"*{extension}")]
+        selected_path = ask_save_file(extension or "", filetypes)
     else:
-        raise ValueError("Недопустимый тип пути: используйте 'folder', 'file' или 'save_file'.")
+        raise ValueError(
+            "Недопустимый тип пути: используйте 'folder', 'file' или 'save_file'."
+        )
 
     if selected_path:
         entry_widget.delete(0, tk.END)


### PR DESCRIPTION
## Summary
- добавлено указание расширения `.cfile` при выборе пути сохранения
- диалог сохранения файла теперь принудительно дописывает нужное расширение и поддерживает фильтр типов файлов
- добавлен тест на корректное добавление расширения

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab6e62b6a0832aa9ee58f2074af0ab