### PR TITLE
Use constants for element selection time/type

### DIFF
--- a/tabs/function4tabs4/command_single.py
+++ b/tabs/function4tabs4/command_single.py
@@ -8,23 +8,27 @@ from pathlib import PureWindowsPath
 from .naming import safe_name
 
 
+ETYPE = 1
+ETIME = 4
+
+
 # Шаблоны выбора сущности в LS-PrePost.
 # Ключем служит кортеж (entity_kind, element_type).
 SELECT_TEMPLATES: Dict[Tuple[str, str | None], List[str]] = {
     ("element", "beam"): [
         "genselect clear all",
         "genselect beam add beam {element_id}/0",
-        "etype 1 ;etime 4",
+        f"etype {ETYPE} ;etime {ETIME}",
     ],
     ("element", "shell"): [
         "genselect clear all",
         "genselect shell add shell {element_id}/0",
-        "etype 1 ;etime 4",
+        f"etype {ETYPE} ;etime {ETIME}",
     ],
     ("element", "solid"): [
         "genselect clear all",
         "genselect solid add solid {element_id}/0",
-        "etype 1 ;etime 4",
+        f"etype {ETYPE} ;etime {ETIME}",
     ],
     ("node", None): [
         "genselect clear all",

--- a/tests/test_command_single.py
+++ b/tests/test_command_single.py
@@ -1,5 +1,9 @@
 import pytest
-from tabs.function4tabs4.command_single import build_curve_commands
+from tabs.function4tabs4.command_single import (
+    build_curve_commands,
+    ETYPE,
+    ETIME,
+)
 
 
 def test_build_curve_commands_element():
@@ -14,7 +18,7 @@ def test_build_curve_commands_element():
     assert cmds == [
         "genselect clear all",
         "genselect beam add beam 7/0",
-        "etype 1 ;etime 4",
+        f"etype {ETYPE} ;etime {ETIME}",
         'xyplot 1 savefile curve_file "C:\\proj\\curves\\pilon-element-beam\\static\\7.txt" 1 all',
         "xyplot 1 donemenu",
         "deletewin 1",


### PR DESCRIPTION
## Summary
- define `ETYPE` and `ETIME` constants in command builder
- use constants in `SELECT_TEMPLATES` instead of literals
- update tests to construct expectations from constants

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab7534fbf4832a8d8a9edb61a0352a