### PR TITLE
Определение etype и etime через словари

### DIFF
--- a/tests/test_command_all.py
+++ b/tests/test_command_all.py
@@ -1,4 +1,5 @@
 from pathlib import Path, PureWindowsPath
+from analysis_types import AnalysisType
 from tabs.function4tabs4.command_all import collect_commands, walk_tree_and_build_commands
 from tabs.function4tabs4.tree_schema import Tree, AnalysisFolder, CurveNode
 from tabs.function4tabs4.naming import safe_name
@@ -20,15 +21,16 @@ def test_collect_commands():
 
 
 def test_walk_tree_and_build_commands(tmp_path):
+    analysis = AnalysisType.TIME_AXIAL_FORCE.value
     entity = EntityNode(
         user_name="user",
         entity_kind="node",
-        children=[AnalysisNode("static", children=[FileNode(1)])],
+        children=[AnalysisNode(analysis, children=[FileNode(1)])],
     )
     commands = walk_tree_and_build_commands([entity], base_project_dir=tmp_path)
     top_folder = encode_topfolder("user", "node")
     expected_path = PureWindowsPath(
-        tmp_path, "curves", top_folder, "static", "1.txt"
+        tmp_path, "curves", top_folder, analysis, "1.txt"
     )
     assert commands == [
         "genselect clear all",

--- a/tests/test_command_single.py
+++ b/tests/test_command_single.py
@@ -1,16 +1,20 @@
 import pytest
+from analysis_types import AnalysisType
 from tabs.function4tabs4.command_single import (
     build_curve_commands,
-    ETYPE,
-    ETIME,
+    ETYPE_BY_ELEMENT,
+    ETIME_BY_ANALYSIS,
 )
 
 
 def test_build_curve_commands_element():
+    analysis = AnalysisType.TIME_AXIAL_FORCE.value
+    etype = ETYPE_BY_ELEMENT["beam"]
+    etime = ETIME_BY_ANALYSIS[analysis]
     cmds = build_curve_commands(
         base_project_dir="C:\\proj",
         top_folder_name="pilon-element-beam",
-        analysis_type="static",
+        analysis_type=analysis,
         entity_kind="element",
         element_type="beam",
         element_id=7,
@@ -18,18 +22,19 @@ def test_build_curve_commands_element():
     assert cmds == [
         "genselect clear all",
         "genselect beam add beam 7/0",
-        f"etype {ETYPE} ;etime {ETIME}",
-        'xyplot 1 savefile curve_file "C:\\proj\\curves\\pilon-element-beam\\static\\7.txt" 1 all',
+        f"etype {etype} ;etime {etime}",
+        f'xyplot 1 savefile curve_file "C:\\proj\\curves\\pilon-element-beam\\{analysis}\\7.txt" 1 all',
         "xyplot 1 donemenu",
         "deletewin 1",
     ]
 
 
 def test_build_curve_commands_node():
+    analysis = AnalysisType.TIME_AXIAL_FORCE.value
     cmds = build_curve_commands(
         base_project_dir="C:\\proj",
         top_folder_name="uzli-node",
-        analysis_type="dynamic",
+        analysis_type=analysis,
         entity_kind="node",
         element_type=None,
         element_id=15,
@@ -37,7 +42,7 @@ def test_build_curve_commands_node():
     assert cmds == [
         "genselect clear all",
         "genselect node add node 15",
-        'xyplot 1 savefile curve_file "C:\\proj\\curves\\uzli-node\\dynamic\\15.txt" 1 all',
+        f'xyplot 1 savefile curve_file "C:\\proj\\curves\\uzli-node\\{analysis}\\15.txt" 1 all',
         "xyplot 1 donemenu",
         "deletewin 1",
     ]
@@ -47,6 +52,7 @@ def test_build_curve_commands_node():
     "kwargs",
     [
         {"analysis_type": ""},
+        {"analysis_type": "unsupported"},
         {"entity_kind": "unknown"},
         {"entity_kind": "element", "element_type": "foo"},
         {"entity_kind": "node", "element_type": "beam"},
@@ -57,7 +63,7 @@ def test_build_curve_commands_invalid(kwargs):
     base_args = dict(
         base_project_dir="C:\\proj",
         top_folder_name="p-node",
-        analysis_type="static",
+        analysis_type=AnalysisType.TIME_AXIAL_FORCE.value,
         entity_kind="node",
         element_type=None,
         element_id=1,


### PR DESCRIPTION
## Summary
- Убраны глобальные константы `ETYPE` и `ETIME`
- Введены словари `ETYPE_BY_ELEMENT` и `ETIME_BY_ANALYSIS`
- Команды выбора формируются с учётом типа элемента и анализа
- Обновлены тесты

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab79da49b8832a9837db5aa314d2f3