### PR TITLE
Выбор типов анализа по типу элемента

### DIFF
--- a/analysis_types.py
+++ b/analysis_types.py
@@ -2,20 +2,21 @@ from enum import Enum
 
 class AnalysisType(str, Enum):
     """Допустимые типы анализа."""
-    TIME_AXIAL_FORCE = "Время-Продольная сила"
-    TIME_SHEAR_FORCE_Y = "Время-Поперечная сила по Y"
-    TIME_SHEAR_FORCE_Z = "Время-Поперечная сила по Z"
-    TIME_BENDING_MOMENT_MS_MY = "Время-Изгибающий момент Ms (My)"
-    TIME_BENDING_MOMENT_MT_MZ = "Время-Изгибающий момент Mt (Mz)"
-    TIME_TORQUE_MX = "Время-Крутящий момент Mx"
-    TIME_NORMAL_STRESS_X = "Время-Нормальное напряжение X"
-    TIME_SHEAR_STRESS_XY = "Время-Касательное напряжение XY"
-    TIME_SHEAR_STRESS_ZX = "Время-Касательное напряжение ZX"
+
+    TIME_AXIAL_FORCE = "Время - Продольная сила"
+    TIME_SHEAR_FORCE_Y = "Время - Поперечная сила по Y"
+    TIME_SHEAR_FORCE_Z = "Время - Поперечная сила по Z"
+    TIME_BENDING_MOMENT_MS_MY = "Время - Изгибающий момент Ms (My)"
+    TIME_BENDING_MOMENT_MT_MZ = "Время - Изгибающий момент Mt (Mz)"
+    TIME_TORQUE_MX = "Время - Крутящий момент Mx"
+    TIME_NORMAL_STRESS_X = "Время - Нормальное напряжение X"
+    TIME_SHEAR_STRESS_XY = "Время - Касательное напряжение XY"
+    TIME_SHEAR_STRESS_ZX = "Время - Касательное напряжение ZX"
     TIME_PLASTIC_STRAIN_INTENSITY = (
-        "Время-Интенсивность пластических деформаций"
+        "Время - Интенсивность пластических деформаций"
     )
-    TIME_ELONGATION = "Время-Удлинение"
-    TIME_STRESS_INTENSITY = "Время-Интенсивность напряжений"
+    TIME_ELONGATION = "Время - Удлинение"
+    TIME_STRESS_INTENSITY = "Время - Интенсивность напряжений"
 
     @classmethod
     def list(cls) -> list[str]:
@@ -24,4 +25,12 @@ class AnalysisType(str, Enum):
 
 ANALYSIS_TYPES = AnalysisType.list()
 
-__all__ = ["AnalysisType", "ANALYSIS_TYPES"]
+# Карта доступных типов анализа для разных типов элементов.
+# В дальнейшем список для оболочек и узлов может быть расширен.
+ANALYSIS_TYPES_BY_ELEMENT: dict[str | None, list[str]] = {
+    "beam": ANALYSIS_TYPES,
+    "shell": [],
+    "node": [],
+}
+
+__all__ = ["AnalysisType", "ANALYSIS_TYPES", "ANALYSIS_TYPES_BY_ELEMENT"]

--- a/plot_from_txt.py
+++ b/plot_from_txt.py
@@ -23,7 +23,7 @@ def extract_labels(analysis_type: str) -> tuple[str, str]:
     Parameters
     ----------
     analysis_type:
-        Строка вида ``"Время-Продольная сила"``.
+        Строка вида ``"Время - Продольная сила"``.
 
     Returns
     -------
@@ -84,7 +84,7 @@ def main() -> None:
     parser.add_argument("txt_file", help="Путь к входному TXT файлу")
     parser.add_argument(
         "analysis_type",
-        help="Тип анализа, например 'Время-Продольная сила'",
+        help="Тип анализа, например 'Время - Продольная сила'",
     )
     parser.add_argument(
         "-o",

--- a/tabs/tab4.py
+++ b/tabs/tab4.py
@@ -19,7 +19,7 @@ from tree_schema import AnalysisNode, EntityNode, FileNode
 from ui import constants as ui_const
 from widgets import create_text, select_path
 from curves_pipeline import build_curves_report
-from analysis_types import ANALYSIS_TYPES
+from analysis_types import ANALYSIS_TYPES_BY_ELEMENT
 
 
 class AnalysisTypeDialog(simpledialog.Dialog):
@@ -224,9 +224,15 @@ def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:
         item = sel[0]
         parent = tree.parent(item)
 
+        try:
+            _, _, element_type = decode_topfolder(tree.item(item, "text"))
+        except Exception:
+            element_type = None
+
         if parent == "":
+            values = ANALYSIS_TYPES_BY_ELEMENT.get(element_type, [])
             dlg = AnalysisTypeDialog(
-                tab4, title="Выбор типа анализа", values=ANALYSIS_TYPES
+                tab4, title="Выбор типа анализа", values=values
             )
             choice = dlg.result
             if choice:

--- a/tests/test_tab4_top_nodes.py
+++ b/tests/test_tab4_top_nodes.py
@@ -5,6 +5,7 @@ from tkinter import ttk
 import tabs.tab4 as tab4mod
 from tabs.tab4 import create_tab4
 from topfolder_codec import encode_topfolder
+from analysis_types import ANALYSIS_TYPES_BY_ELEMENT
 
 
 def _create_app():
@@ -53,4 +54,34 @@ def test_add_rename_remove_top_nodes(monkeypatch):
 
     tab.remove_node()
     assert len(tree.get_children()) == start
+    root.destroy()
+
+
+def test_analysis_types_dependent_on_element_type(monkeypatch):
+    root, tab = _create_app()
+    tree = tab.tree
+
+    captured: list[list[str]] = []
+
+    class DummyDialog:
+        def __init__(self, _parent, title, values):  # noqa: D401
+            captured.append(values)
+            self.result = None
+
+    monkeypatch.setattr(tab4mod, "AnalysisTypeDialog", DummyDialog)
+
+    beam_top = tree.insert(
+        "", "end", text=encode_topfolder("b", "element", "beam")
+    )
+    tree.selection_set(beam_top)
+    tab.add_node()
+
+    shell_top = tree.insert(
+        "", "end", text=encode_topfolder("s", "element", "shell")
+    )
+    tree.selection_set(shell_top)
+    tab.add_node()
+
+    assert captured[0] == ANALYSIS_TYPES_BY_ELEMENT["beam"]
+    assert captured[1] == ANALYSIS_TYPES_BY_ELEMENT["shell"]
     root.destroy()


### PR DESCRIPTION
## Изменения
- добавлены новые наименования типов анализа и карта доступных анализов по типам элементов
- вкладка 4 выбирает список анализов исходя из типа верхнего узла
- обновлена документация для формата "Время - <название>"
- расширены тесты для проверки выбора списка анализов

## Проверка
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab7ac34794832abff25e43d6faa809