### PR TITLE
Обработка Unicode путей и тест кириллицы

### DIFF
--- a/tabs/function4tabs4/cfile_writer.py
+++ b/tabs/function4tabs4/cfile_writer.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+import os
 
 
-def write_cfile(commands: list[str], out_path: str) -> Path:
+def write_cfile(commands: list[str], out_path: str | os.PathLike[str] | bytes) -> Path:
     """Записать ``commands`` в файл ``out_path``."""
-    dest = Path(out_path)
+    dest = Path(os.fsdecode(out_path))
     try:
         with dest.open("w", encoding="utf-8", newline="\r\n") as file:
             file.write("\n".join(commands) + "\n")

--- a/tabs/function4tabs4/tree_io.py
+++ b/tabs/function4tabs4/tree_io.py
@@ -3,22 +3,23 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
 from .tree_schema import Tree
 
 
-def save_tree(tree: Tree, path: str | Path) -> Path:
+def save_tree(tree: Tree, path: str | os.PathLike[str] | bytes) -> Path:
     """Сохранить ``tree`` в JSON файл ``path``."""
-    dest = Path(path)
+    dest = Path(os.fsdecode(path))
     dest.write_text(json.dumps(tree.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8")
     return dest
 
 
-def load_tree(path: str | Path) -> Tree:
+def load_tree(path: str | os.PathLike[str] | bytes) -> Tree:
     """Загрузить дерево из JSON файла."""
-    src = Path(path)
+    src = Path(os.fsdecode(path))
     data: Any = json.loads(src.read_text(encoding="utf-8"))
     return Tree.from_dict(data)
 

--- a/tests/test_unicode_paths.py
+++ b/tests/test_unicode_paths.py
@@ -1,0 +1,23 @@
+import os
+from tabs.function4tabs4.cfile_writer import write_cfile
+from tabs.function4tabs4.tree_io import save_tree, load_tree
+from tabs.function4tabs4.tree_schema import Tree, AnalysisFolder, CurveNode
+
+
+def test_cyrillic_paths(tmp_path):
+    workdir = tmp_path / "папка"
+    workdir.mkdir()
+
+    cfile_path = workdir / "команды.cfile"
+    tree_path = workdir / "дерево.json"
+
+    # Проверка записи и чтения .cfile по байтовому пути
+    commands = ["привет", "мир"]
+    write_cfile(commands, os.fsencode(cfile_path))
+    assert cfile_path.read_text(encoding="utf-8") == "привет\nмир\n"
+
+    # Проверка сохранения и загрузки дерева по байтовому пути
+    tree = Tree(top="T", analyses=[AnalysisFolder(name="A", curves=[CurveNode(name="c", path="p")])])
+    save_tree(tree, os.fsencode(tree_path))
+    loaded = load_tree(os.fsencode(tree_path))
+    assert loaded.to_dict() == tree.to_dict()


### PR DESCRIPTION
## Summary
- обрабатываются байтовые пути через `os.fsdecode`
- добавлен тест, проверяющий сохранение и загрузку по кириллическому пути

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab7e5ae8f0832a86df809a0ff382eb