### PR TITLE
Использование Path для файловых операций

### DIFF
--- a/tabs/function4tabs4/cfile_writer.py
+++ b/tabs/function4tabs4/cfile_writer.py
@@ -3,18 +3,16 @@
 from __future__ import annotations
 
 from pathlib import Path
-import os
 
 
-def write_cfile(commands: list[str], out_path: str | os.PathLike[str] | bytes) -> Path:
+def write_cfile(commands: list[str], out_path: Path) -> Path:
     """Записать ``commands`` в файл ``out_path``."""
-    dest = Path(os.fsdecode(out_path))
     try:
-        with dest.open("w", encoding="utf-8", newline="\r\n") as file:
+        with out_path.open("w", encoding="utf-8", newline="\r\n") as file:
             file.write("\n".join(commands) + "\n")
     except OSError as exc:
-        raise RuntimeError(f"Не удалось записать файл {dest}") from exc
-    return dest
+        raise RuntimeError(f"Не удалось записать файл {out_path}") from exc
+    return out_path
 
 
 __all__ = ["write_cfile"]

--- a/tabs/function4tabs4/tree_io.py
+++ b/tabs/function4tabs4/tree_io.py
@@ -3,24 +3,21 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Any
 
 from .tree_schema import Tree
 
 
-def save_tree(tree: Tree, path: str | os.PathLike[str] | bytes) -> Path:
+def save_tree(tree: Tree, path: Path) -> Path:
     """Сохранить ``tree`` в JSON файл ``path``."""
-    dest = Path(os.fsdecode(path))
-    dest.write_text(json.dumps(tree.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8")
-    return dest
+    path.write_text(json.dumps(tree.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
 
 
-def load_tree(path: str | os.PathLike[str] | bytes) -> Tree:
+def load_tree(path: Path) -> Tree:
     """Загрузить дерево из JSON файла."""
-    src = Path(os.fsdecode(path))
-    data: Any = json.loads(src.read_text(encoding="utf-8"))
+    data: Any = json.loads(path.read_text(encoding="utf-8"))
     return Tree.from_dict(data)
 
 

--- a/tabs/tab4.py
+++ b/tabs/tab4.py
@@ -332,10 +332,12 @@ def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:
 
     # --- Генерация файлов ---
     def generate_cfile() -> None:
-        path = cfile_entry.get().strip()
-        if not path:
+        path_str = cfile_entry.get().strip()
+        if not path_str:
             messagebox.showerror("Ошибка", "Укажите путь к .cfile", parent=tab4)
             return
+
+        path = Path(path_str)
 
         try:
             roots = treeview_to_entity_nodes(tree)
@@ -343,7 +345,7 @@ def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:
             messagebox.showerror("Ошибка", str(exc), parent=tab4)
             return
 
-        commands = walk_tree_and_build_commands(roots, Path(path).parent)
+        commands = walk_tree_and_build_commands(roots, path.parent)
         write_cfile(commands, path)
         messagebox.showinfo("Готово", f"C-файл сохранён в {path}", parent=tab4)
 

--- a/tests/test_unicode_paths.py
+++ b/tests/test_unicode_paths.py
@@ -1,4 +1,3 @@
-import os
 from tabs.function4tabs4.cfile_writer import write_cfile
 from tabs.function4tabs4.tree_io import save_tree, load_tree
 from tabs.function4tabs4.tree_schema import Tree, AnalysisFolder, CurveNode
@@ -11,13 +10,13 @@ def test_cyrillic_paths(tmp_path):
     cfile_path = workdir / "команды.cfile"
     tree_path = workdir / "дерево.json"
 
-    # Проверка записи и чтения .cfile по байтовому пути
+    # Проверка записи и чтения .cfile
     commands = ["привет", "мир"]
-    write_cfile(commands, os.fsencode(cfile_path))
+    write_cfile(commands, cfile_path)
     assert cfile_path.read_text(encoding="utf-8") == "привет\nмир\n"
 
-    # Проверка сохранения и загрузки дерева по байтовому пути
+    # Проверка сохранения и загрузки дерева
     tree = Tree(top="T", analyses=[AnalysisFolder(name="A", curves=[CurveNode(name="c", path="p")])])
-    save_tree(tree, os.fsencode(tree_path))
-    loaded = load_tree(os.fsencode(tree_path))
+    save_tree(tree, tree_path)
+    loaded = load_tree(tree_path)
     assert loaded.to_dict() == tree.to_dict()


### PR DESCRIPTION
## Summary
- принимать только `Path` в функциях записи и чтения файлов
- обновить вызовы в интерфейсе и тестах

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab84b4fd00832a97eeebed959db4c5