### PR TITLE
Выбор кодировки при записи cfile

### DIFF
--- a/tabs/function4tabs4/cfile_writer.py
+++ b/tabs/function4tabs4/cfile_writer.py
@@ -3,13 +3,20 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
 
 def write_cfile(commands: list[str], out_path: Path) -> Path:
-    """Записать ``commands`` в файл ``out_path``."""
+    """Записать ``commands`` в файл ``out_path``.
+
+    Кодировка CP1251 выбирается при наличии кириллических символов, иначе UTF-8.
+    """
     out_path = Path(out_path).resolve()
+    encoding = (
+        "cp1251" if any(re.search(r"[А-Яа-яЁё]", cmd) for cmd in commands) else "utf-8"
+    )
     try:
-        with out_path.open("w", encoding="utf-8", newline="\r\n") as file:
+        with out_path.open("w", encoding=encoding, newline="\r\n") as file:
             file.write("\n".join(commands) + "\n")
     except OSError as exc:
         raise RuntimeError(f"Не удалось записать файл {out_path}") from exc

--- a/tests/test_unicode_paths.py
+++ b/tests/test_unicode_paths.py
@@ -13,7 +13,7 @@ def test_cyrillic_paths(tmp_path):
     # Проверка записи и чтения .cfile
     commands = ["привет", "мир"]
     write_cfile(commands, cfile_path)
-    assert cfile_path.read_text(encoding="utf-8") == "привет\nмир\n"
+    assert cfile_path.read_text(encoding="cp1251") == "привет\nмир\n"
 
     # Проверка сохранения и загрузки дерева
     tree = Tree(top="T", analyses=[AnalysisFolder(name="A", curves=[CurveNode(name="c", path="p")])])


### PR DESCRIPTION
## Summary
- Определён выбор кодировки: CP1251 при наличии кириллицы в командах, иначе UTF-8
- Кодировка передаётся при записи файла .cfile
- Исправлен тест на запись кириллических путей

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab89d97884832a919af23f01966c4b