### PR TITLE
Поддержка файлов LS-DYNA при построении графиков

### DIFF
--- a/plot_from_txt.py
+++ b/plot_from_txt.py
@@ -1,19 +1,17 @@
 from __future__ import annotations
 
-"""Построение PNG-графика по данным из текстового файла.
+"""Построение PNG-графика по данным из файла.
 
 Стили оформления и обработка подписей осей переиспользуются из утилит
-Tab1, используемых в графическом интерфейсе проекта.
+Tab1, используемых в графическом интерфейсе проекта. Файл может быть
+как простым текстовым, так и в формате LS-DYNA.
 """
 
 from pathlib import Path
 import argparse
 
 from tabs.function_for_all_tabs.validation import ensure_analysis_type
-from tabs.functions_for_tab1.curves_from_file.text_file import (
-    read_X_Y_from_text_file,
-)
-from tabs.function_for_all_tabs import create_plot
+from tabs.function_for_all_tabs import create_plot, read_pairs_any
 from tabs.title_utils import format_signature
 
 
@@ -45,7 +43,8 @@ def plot_from_txt(txt_file: str, analysis_type: str, output: str | None = None) 
     Parameters
     ----------
     txt_file:
-        Путь к текстовому файлу с двумя столбцами чисел ``X Y``.
+        Путь к файлу с числовыми данными ``X Y``. Поддерживаются текстовый
+        формат и файлы LS-DYNA.
     analysis_type:
         Тип анализа из :mod:`analysis_types`.
     output:
@@ -58,10 +57,11 @@ def plot_from_txt(txt_file: str, analysis_type: str, output: str | None = None) 
         Путь к сохранённому файлу PNG.
     """
 
-    curve_info: dict[str, list[float]] = {"curve_file": txt_file}
-    read_X_Y_from_text_file(curve_info)
-    if "X_values" not in curve_info or "Y_values" not in curve_info:
-        raise ValueError("Не удалось прочитать данные из текстового файла")
+    xs, ys = read_pairs_any(txt_file)
+    if not xs or not ys:
+        raise ValueError("Не удалось прочитать данные из файла")
+
+    curve_info = {"curve_file": txt_file, "X_values": xs, "Y_values": ys}
 
     x_label, y_label = extract_labels(analysis_type)
     output_path = output or str(Path(txt_file).with_suffix(".png"))
@@ -79,9 +79,9 @@ def plot_from_txt(txt_file: str, analysis_type: str, output: str | None = None) 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Построить PNG-график по данным из текстового файла",
+        description="Построить PNG-график по данным из файла",
     )
-    parser.add_argument("txt_file", help="Путь к входному TXT файлу")
+    parser.add_argument("txt_file", help="Путь к входному файлу с данными")
     parser.add_argument(
         "analysis_type",
         help="Тип анализа, например 'Время - Продольная сила'",

--- a/tabs/function_for_all_tabs/readers.py
+++ b/tabs/function_for_all_tabs/readers.py
@@ -32,13 +32,14 @@ def read_pairs_any(
     suffix = path.suffix.lower()
     if suffix in {".xlsx", ".xlsm", ".csv"}:
         read_excel(curve_info)
-    elif suffix == ".txt":
-        read_text(curve_info)
     else:
         try:
             read_ls_dyna(curve_info)
         except Exception:
             read_text(curve_info)
+        else:
+            if "X_values" not in curve_info or "Y_values" not in curve_info:
+                read_text(curve_info)
     return curve_info.get("X_values", []), curve_info.get("Y_values", [])
 
 

--- a/tests/test_plot_from_ls_dyna.py
+++ b/tests/test_plot_from_ls_dyna.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from analysis_types import AnalysisType
+from plot_from_txt import plot_from_txt
+from PIL import Image
+
+
+def _fake_create_plot(curves_info, x_label, y_label, title, save_file, file_plt, **kwargs):
+    Image.new("RGB", (1, 1), color="white").save(file_plt)
+
+
+def test_plot_from_ls_dyna(tmp_path):
+    txt_file = (
+        Path(__file__).resolve().parents[1]
+        / "examples"
+        / "LsDynaText"
+        / "LsDyna_example.txt"
+    )
+    output = tmp_path / "curve.png"
+    with patch("plot_from_txt.create_plot", side_effect=_fake_create_plot):
+        result = plot_from_txt(
+            str(txt_file), AnalysisType.TIME_AXIAL_FORCE.value, str(output)
+        )
+    assert output.exists()
+    assert result == str(output)


### PR DESCRIPTION
## Summary
- Добавлена универсальная загрузка данных для построения графиков, распознающая файлы LS-DYNA
- Переписан читатель `read_pairs_any`, который сначала пытается интерпретировать входные файлы как LS-DYNA
- Добавлен тест на построение графика из файла LS-DYNA

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abee8710e0832a9010bf45f2a3a008