### PR TITLE
Обработка корневого пути проекта при генерации кривых

### DIFF
--- a/tabs/tab4.py
+++ b/tabs/tab4.py
@@ -187,6 +187,18 @@ def treeview_to_entity_nodes(tree: ttk.Treeview) -> list[EntityNode]:
     return roots
 
 
+def _adjust_curves_root(path: Path) -> tuple[Path | None, str | None]:
+    """Проверить ``path`` на признак корня проекта и вернуть папку с кривыми."""
+
+    markers = ("pyproject.toml", ".git")
+    if any((path / m).exists() for m in markers):
+        curves_dir = path / "curves"
+        if curves_dir.is_dir():
+            return curves_dir, None
+        return None, f"В проекте {path} отсутствует подкаталог 'curves'"
+    return path, None
+
+
 def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:
     """Создать четвёртую вкладку приложения."""
 
@@ -368,6 +380,10 @@ def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:
         root = Path(path)
         if not root.exists():
             messagebox.showerror("Ошибка", f"Папка {path} не найдена", parent=tab4)
+            return
+        root, err = _adjust_curves_root(root)
+        if err:
+            messagebox.showerror("Ошибка", err, parent=tab4)
             return
 
         docx_path, errors = build_curves_report(root)

--- a/tests/test_adjust_curves_root.py
+++ b/tests/test_adjust_curves_root.py
@@ -1,0 +1,23 @@
+from tabs import tab4
+
+
+def test_adjust_curves_root_regular_dir(tmp_path):
+    resolved, err = tab4._adjust_curves_root(tmp_path)
+    assert err is None
+    assert resolved == tmp_path
+
+
+def test_adjust_curves_root_project_with_curves(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+    curves = tmp_path / "curves"
+    curves.mkdir()
+    resolved, err = tab4._adjust_curves_root(tmp_path)
+    assert err is None
+    assert resolved == curves
+
+
+def test_adjust_curves_root_project_without_curves(tmp_path):
+    (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+    resolved, err = tab4._adjust_curves_root(tmp_path)
+    assert resolved is None
+    assert err


### PR DESCRIPTION
## Summary
- Проверка на выбор корня проекта при генерации кривых
- Поддержка использования подкаталога `curves` и сообщение об его отсутствии
- Тесты для проверки нового поведения

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abf2aefa40832aa88bcc2c698af123