### PR TITLE
Учет пустых разделов при сканировании кривых

### DIFF
--- a/curves_pipeline.py
+++ b/curves_pipeline.py
@@ -27,7 +27,8 @@ def build_curves_report(curves_root: Path | str) -> Tuple[Path | None, List[str]
     errors: List[str] = []
 
     try:
-        structure = scan_curves(root)
+        structure, scan_errors = scan_curves(root)
+        errors.extend(scan_errors)
     except Exception as exc:  # pragma: no cover - защитный код
         errors.append(f"Сканирование: {exc}")
         structure = {}

--- a/tests/test_curves_pipeline_errors.py
+++ b/tests/test_curves_pipeline_errors.py
@@ -1,0 +1,6 @@
+from curves_pipeline import build_curves_report
+
+
+def test_build_curves_report_propagates_scan_errors(tmp_path):
+    _, errors = build_curves_report(tmp_path)
+    assert any("Не найдено ни одной топ-папки" in e for e in errors)

--- a/tests/test_curves_scan.py
+++ b/tests/test_curves_scan.py
@@ -27,7 +27,7 @@ def test_scan_curves_collects_files(tmp_path):
         },
     }
 
-    result = scan_curves(tmp_path)
+    result, errors = scan_curves(tmp_path)
 
     for analyses in expected.values():
         for files in analyses.values():
@@ -37,6 +37,7 @@ def test_scan_curves_collects_files(tmp_path):
             files.sort()
 
     assert result == expected
+    assert not errors
 
 
 def test_scan_curves_empty_or_missing(tmp_path):
@@ -45,6 +46,19 @@ def test_scan_curves_empty_or_missing(tmp_path):
     # Топ-папка без подпапок анализа
     (tmp_path / "uzli-node").mkdir()
 
-    result = scan_curves(tmp_path)
+    result, errors = scan_curves(tmp_path)
 
     assert result == {}
+    assert sorted(errors) == sorted(
+        [
+            "Топ-папка 'pilon-element-beam' не содержит подпапок анализов",
+            "Топ-папка 'uzli-node' не содержит подпапок анализов",
+        ]
+    )
+
+
+def test_scan_curves_no_top_folders(tmp_path):
+    result, errors = scan_curves(tmp_path)
+
+    assert result == {}
+    assert errors == ["Не найдено ни одной топ-папки"]


### PR DESCRIPTION
## Summary
- фиксировать отсутствие топ-папок и пустых разделов в `scan_curves`
- передавать найденные ошибки через `build_curves_report`
- добавить тесты на новые проверки

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abf36d338c832a8a27cf7bf07ff0ef