### PR TITLE
Фиксация пустых подпапок в сканере кривых

### DIFF
--- a/curves_pipeline.py
+++ b/curves_pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import List, Tuple
+import logging
 
 from curves_scan import scan_curves
 from plot_from_txt import plot_from_txt
@@ -28,6 +29,11 @@ def build_curves_report(curves_root: Path | str) -> Tuple[Path | None, List[str]
 
     try:
         structure, scan_errors = scan_curves(root)
+        if scan_errors:
+            (root / "errors.log").write_text("\n".join(scan_errors), encoding="utf-8")
+            logging.warning(
+                "Обнаружены проблемы при сканировании, см. errors.log"
+            )
         errors.extend(scan_errors)
     except Exception as exc:  # pragma: no cover - защитный код
         errors.append(f"Сканирование: {exc}")

--- a/curves_scan.py
+++ b/curves_scan.py
@@ -31,10 +31,12 @@ def scan_curves(root_dir: Path | str) -> Tuple[Dict[str, Dict[str, List[str]]], 
 
     for top_path in top_dirs:
         analyses: Dict[str, List[str]] = {}
+        had_subdirs = False
         for analysis_dir in top_path.iterdir():
             if not analysis_dir.is_dir():
                 continue
 
+            had_subdirs = True
             files: List[str] = []
             for file_path in analysis_dir.iterdir():
                 if file_path.is_file() and file_path.suffix in {".png", ".txt"}:
@@ -42,10 +44,15 @@ def scan_curves(root_dir: Path | str) -> Tuple[Dict[str, Dict[str, List[str]]], 
 
             if files:
                 analyses[analysis_dir.name] = files
+            else:
+                errors.append(
+                    f"Подпапка анализа '{analysis_dir.name}' в топ-папке "
+                    f"'{top_path.name}' не содержит файлов"
+                )
 
         if analyses:
             result[top_path.name] = analyses
-        else:
+        elif not had_subdirs:
             errors.append(
                 f"Топ-папка '{top_path.name}' не содержит подпапок анализов"
             )

--- a/tests/test_curves_pipeline_errors.py
+++ b/tests/test_curves_pipeline_errors.py
@@ -1,6 +1,13 @@
+import logging
 from curves_pipeline import build_curves_report
 
 
-def test_build_curves_report_propagates_scan_errors(tmp_path):
+def test_build_curves_report_propagates_scan_errors(tmp_path, caplog):
+    caplog.set_level(logging.WARNING)
     _, errors = build_curves_report(tmp_path)
+    log_file = tmp_path / "errors.log"
+
+    assert log_file.exists()
+    assert "Не найдено ни одной топ-папки" in log_file.read_text(encoding="utf-8")
     assert any("Не найдено ни одной топ-папки" in e for e in errors)
+    assert "обнаружены проблемы" in caplog.text.lower()

--- a/tests/test_curves_scan.py
+++ b/tests/test_curves_scan.py
@@ -51,7 +51,7 @@ def test_scan_curves_empty_or_missing(tmp_path):
     assert result == {}
     assert sorted(errors) == sorted(
         [
-            "Топ-папка 'pilon-element-beam' не содержит подпапок анализов",
+            "Подпапка анализа 'static' в топ-папке 'pilon-element-beam' не содержит файлов",
             "Топ-папка 'uzli-node' не содержит подпапок анализов",
         ]
     )


### PR DESCRIPTION
## Summary
- Логирование пустых подпапок анализа при сканировании
- Запись ошибок сканирования в errors.log и предупреждение

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68abf442e0c8832ab97aa7ec0299a384