### PR TITLE
Поиск подпапки curves без маркеров

### DIFF
--- a/tabs/tab4.py
+++ b/tabs/tab4.py
@@ -196,7 +196,14 @@ def _adjust_curves_root(path: Path) -> tuple[Path | None, str | None]:
         if curves_dir.is_dir():
             return curves_dir, None
         return None, f"В проекте {path} отсутствует подкаталог 'curves'"
-    return path, None
+
+    if path.name == "curves" and path.is_dir():
+        return path, None
+
+    curves_dir = path / "curves"
+    if curves_dir.is_dir():
+        return curves_dir, None
+    return None, f"В директории {path} отсутствует подкаталог 'curves'"
 
 
 def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:

--- a/tests/test_adjust_curves_root.py
+++ b/tests/test_adjust_curves_root.py
@@ -3,8 +3,18 @@ from tabs import tab4
 
 def test_adjust_curves_root_regular_dir(tmp_path):
     resolved, err = tab4._adjust_curves_root(tmp_path)
+    assert resolved is None
+    assert err
+
+
+def test_adjust_curves_root_dir_with_curves_subdir(tmp_path):
+    (tmp_path / "a").mkdir()
+    curves = tmp_path / "curves"
+    curves.mkdir()
+    (tmp_path / "b").mkdir()
+    resolved, err = tab4._adjust_curves_root(tmp_path)
     assert err is None
-    assert resolved == tmp_path
+    assert resolved == curves
 
 
 def test_adjust_curves_root_project_with_curves(tmp_path):


### PR DESCRIPTION
## Summary
- добавлен поиск подпапки `curves` при отсутствии файлов-маркеров проекта
- исправлены и дополнены тесты для `_adjust_curves_root`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abf64ced04832abd8b80ac62826ecc