### PR TITLE
Fix curves path resolution and extend tests

### DIFF
--- a/tabs/tab4.py
+++ b/tabs/tab4.py
@@ -388,14 +388,14 @@ def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:
         if not root.exists():
             messagebox.showerror("Ошибка", f"Папка {path} не найдена", parent=tab4)
             return
-        root, err = _adjust_curves_root(root)
-        if err:
+        curves_root, err = _adjust_curves_root(root)
+        if curves_root is None:
             messagebox.showerror("Ошибка", err, parent=tab4)
             return
 
-        docx_path, errors = build_curves_report(root)
+        docx_path, errors = build_curves_report(curves_root)
         if errors:
-            error_file = root / "errors.log"
+            error_file = curves_root / "errors.log"
             error_file.write_text("\n".join(errors), encoding="utf-8")
             messagebox.showwarning(
                 "Готово с ошибками",

--- a/tests/test_adjust_curves_root.py
+++ b/tests/test_adjust_curves_root.py
@@ -31,3 +31,10 @@ def test_adjust_curves_root_project_without_curves(tmp_path):
     resolved, err = tab4._adjust_curves_root(tmp_path)
     assert resolved is None
     assert err
+
+
+def test_adjust_curves_root_nonexistent_curves_dir(tmp_path):
+    path = tmp_path / "curves"
+    resolved, err = tab4._adjust_curves_root(path)
+    assert resolved is None
+    assert err


### PR DESCRIPTION
## Summary
- ensure tab4 uses the path returned by `_adjust_curves_root` and handles missing `curves` folders
- add a unit test for nonexistent `curves` directory

## Testing
- `pytest tests/test_adjust_curves_root.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abf824b9ec832a8fa6c759c77556ab