### PR TITLE
Handle missing curves folder explicitly

### DIFF
--- a/tabs/tab4.py
+++ b/tabs/tab4.py
@@ -188,19 +188,13 @@ def treeview_to_entity_nodes(tree: ttk.Treeview) -> list[EntityNode]:
 
 
 def _adjust_curves_root(path: Path) -> tuple[Path | None, str | None]:
-    """Проверить ``path`` на признак корня проекта и вернуть папку с кривыми."""
+    """Проверить ``path`` на наличие подпапки ``curves``.
 
-    markers = ("pyproject.toml", ".git")
-    if any((path / m).exists() for m in markers):
-        curves_dir = path / "curves"
-        if curves_dir.is_dir():
-            return curves_dir, None
-        return None, f"В проекте {path} отсутствует подкаталог 'curves'"
+    Возвращает кортеж ``(путь, None)`` при успешном поиске подпапки или
+    ``(None, сообщение об ошибке)`` в противном случае.
+    """
 
-    if path.name == "curves" and path.is_dir():
-        return path, None
-
-    curves_dir = path / "curves"
+    curves_dir = path if path.name == "curves" else path / "curves"
     if curves_dir.is_dir():
         return curves_dir, None
     return None, f"В директории {path} отсутствует подкаталог 'curves'"

--- a/tests/test_adjust_curves_root.py
+++ b/tests/test_adjust_curves_root.py
@@ -4,7 +4,7 @@ from tabs import tab4
 def test_adjust_curves_root_regular_dir(tmp_path):
     resolved, err = tab4._adjust_curves_root(tmp_path)
     assert resolved is None
-    assert err
+    assert err == f"В директории {tmp_path} отсутствует подкаталог 'curves'"
 
 
 def test_adjust_curves_root_dir_with_curves_subdir(tmp_path):
@@ -17,24 +17,16 @@ def test_adjust_curves_root_dir_with_curves_subdir(tmp_path):
     assert resolved == curves
 
 
-def test_adjust_curves_root_project_with_curves(tmp_path):
-    (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
-    curves = tmp_path / "curves"
-    curves.mkdir()
-    resolved, err = tab4._adjust_curves_root(tmp_path)
-    assert err is None
-    assert resolved == curves
-
-
-def test_adjust_curves_root_project_without_curves(tmp_path):
-    (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
-    resolved, err = tab4._adjust_curves_root(tmp_path)
-    assert resolved is None
-    assert err
-
-
 def test_adjust_curves_root_nonexistent_curves_dir(tmp_path):
     path = tmp_path / "curves"
     resolved, err = tab4._adjust_curves_root(path)
     assert resolved is None
     assert err
+
+
+def test_adjust_curves_root_missing_curves_subdir(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    resolved, err = tab4._adjust_curves_root(project)
+    assert resolved is None
+    assert err == f"В директории {project} отсутствует подкаталог 'curves'"


### PR DESCRIPTION
## Summary
- Simplify `_adjust_curves_root` to only validate existence of `curves` subdirectory
- Extend tests for `_adjust_curves_root` with missing `curves` cases

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abf8c8b8a4832abdd4f4d7778a4cb3