### PR TITLE
Учитывать тип сущности при построении графиков

### DIFF
--- a/plot_from_txt.py
+++ b/plot_from_txt.py
@@ -13,7 +13,13 @@ import argparse
 from tabs.function_for_all_tabs.validation import ensure_analysis_type
 from tabs.function_for_all_tabs import create_plot, read_pairs_any
 from tabs.functions_for_tab1.plotting import TitleProcessor
-from tabs.constants import DEFAULT_UNITS, TITLE_TRANSLATIONS, TITLES_SYMBOLS
+from tabs.constants import (
+    DEFAULT_UNITS,
+    TITLE_TRANSLATIONS,
+    TITLES_SYMBOLS,
+    LEGEND_TITLE_TRANSLATIONS,
+)
+from topfolder_codec import decode_topfolder
 
 
 def extract_labels(analysis_type: str) -> tuple[str, str, str]:
@@ -140,13 +146,17 @@ def plot_from_txt_files(txt_files: list[str], analysis_type: str) -> str:
     analysis_dir = Path(txt_files[0]).parent
     output_path = str(analysis_dir.with_suffix(".png"))
 
+    _, entity_kind, _ = decode_topfolder(analysis_dir.parent.name)
+    legend_key = "№ Элементов" if entity_kind == "element" else "№ Узлов"
+    legend_title = LEGEND_TITLE_TRANSLATIONS[legend_key]["Русский"]
+
     create_plot(
         curves,
         x_label=x_label,
         y_label=y_label,
         title=title,
         legend=True,
-        legend_title=analysis_type,
+        legend_title=legend_title,
         save_file=True,
         file_plt=output_path,
     )

--- a/tests/test_plot_from_txt.py
+++ b/tests/test_plot_from_txt.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from plot_from_txt import extract_labels, plot_from_txt
+from plot_from_txt import extract_labels, plot_from_txt, plot_from_txt_files
 from analysis_types import AnalysisType
+from tabs.constants import LEGEND_TITLE_TRANSLATIONS
 
 
 def test_extract_labels():
@@ -23,5 +24,30 @@ def test_plot_from_txt(tmp_path):
 
     with patch("plot_from_txt.create_plot", side_effect=fake_create_plot) as mocked:
         result = plot_from_txt(str(txt_file), AnalysisType.TIME_AXIAL_FORCE.value, str(out_file))
+        mocked.assert_called_once()
+    assert Path(result).exists()
+
+
+def test_plot_from_txt_files(tmp_path):
+    top = tmp_path / "pilon-element-beam"
+    analysis_dir = top / "analysis"
+    analysis_dir.mkdir(parents=True)
+
+    data = "0 0\n1 1\n"
+    f1 = analysis_dir / "10.txt"
+    f1.write_text(data, encoding="utf-8")
+    f2 = analysis_dir / "20.txt"
+    f2.write_text(data, encoding="utf-8")
+
+    expected_legend = LEGEND_TITLE_TRANSLATIONS["№ Элементов"]["Русский"]
+
+    def fake_create_plot(curves_info, x_label, y_label, title, legend, legend_title, save_file, file_plt, **kwargs):
+        assert [c["curve_legend"] for c in curves_info] == ["10", "20"]
+        assert legend is True
+        assert legend_title == expected_legend
+        Path(file_plt).touch()
+
+    with patch("plot_from_txt.create_plot", side_effect=fake_create_plot) as mocked:
+        result = plot_from_txt_files([str(f1), str(f2)], AnalysisType.TIME_AXIAL_FORCE.value)
         mocked.assert_called_once()
     assert Path(result).exists()


### PR DESCRIPTION
## Изменения
- Определение типа сущности через `decode_topfolder` и выбор заголовка легенды из `LEGEND_TITLE_TRANSLATIONS`.
- Передача полученного заголовка графика из `extract_labels` в `create_plot`.
- Тест для проверки формирования легенды по именам файлов.

## Проверки
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68abfee45b6c832aa3f5195ad0235175