### PR TITLE
Исправлено форматирование заголовка графика

### DIFF
--- a/plot_from_txt.py
+++ b/plot_from_txt.py
@@ -58,7 +58,9 @@ def extract_labels(analysis_type: str) -> tuple[str, str, str]:
     y_proc = TitleProcessor(
         y_title, combo_size=y_unit, translations=TITLE_TRANSLATIONS
     )
-    title_proc = TitleProcessor(y_title, combo_size=y_unit, translations=TITLES_SYMBOLS)
+    title_proc = TitleProcessor(
+        y_title, combo_size=y_unit, translations=TITLES_SYMBOLS, bold_math=True
+    )
 
     xlabel = x_proc.get_processed_title()
     ylabel = y_proc.get_processed_title()

--- a/tests/test_plot_from_txt.py
+++ b/tests/test_plot_from_txt.py
@@ -3,14 +3,23 @@ from unittest.mock import patch
 
 from plot_from_txt import extract_labels, plot_from_txt, plot_from_txt_files
 from analysis_types import AnalysisType
-from tabs.constants import LEGEND_TITLE_TRANSLATIONS
+from tabs.constants import (
+    DEFAULT_UNITS,
+    LEGEND_TITLE_TRANSLATIONS,
+    TITLES_SYMBOLS,
+)
+from tabs.title_utils import format_signature
 
 
 def test_extract_labels():
     x, y, title = extract_labels(AnalysisType.TIME_AXIAL_FORCE.value)
     assert x == "Время $\\mathit{\\mathit{t}}$, с"
     assert y == "Продольная сила $\\mathit{\\mathit{N}}$, Н"
-    assert title == y
+    expected_title = format_signature(
+        f"{TITLES_SYMBOLS['Продольная сила']['Русский']}, {DEFAULT_UNITS['Продольная сила']}",
+        bold=True,
+    )
+    assert title == expected_title
 
 
 def test_plot_from_txt(tmp_path):


### PR DESCRIPTION
## Summary
- Добавлен TitleProcessor с жирным выделением математики для заголовка
- Обновлены тесты `plot_from_txt`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac03990b20832abf27adee160674c3