### PR TITLE
Использовать переводы названий графиков

### DIFF
--- a/plot_from_txt.py
+++ b/plot_from_txt.py
@@ -16,7 +16,7 @@ from tabs.functions_for_tab1.plotting import TitleProcessor
 from tabs.constants import (
     DEFAULT_UNITS,
     TITLE_TRANSLATIONS,
-    TITLES_SYMBOLS,
+    TITLE_TRANSLATIONS_BOLD,
     LEGEND_TITLE_TRANSLATIONS,
 )
 from topfolder_codec import decode_topfolder
@@ -49,6 +49,7 @@ def extract_labels(analysis_type: str) -> tuple[str, str, str]:
 
     x_title = Getter(x_raw)
     y_title = Getter(y_raw)
+    graph_title = Getter(y_raw)
     x_unit = Getter(DEFAULT_UNITS.get(x_raw, ""))
     y_unit = Getter(DEFAULT_UNITS.get(y_raw, ""))
 
@@ -59,7 +60,10 @@ def extract_labels(analysis_type: str) -> tuple[str, str, str]:
         y_title, combo_size=y_unit, translations=TITLE_TRANSLATIONS
     )
     title_proc = TitleProcessor(
-        y_title, combo_size=y_unit, translations=TITLES_SYMBOLS, bold_math=True
+        graph_title,
+        combo_size=y_unit,
+        translations=TITLE_TRANSLATIONS_BOLD,
+        bold_math=True,
     )
 
     xlabel = x_proc.get_processed_title()

--- a/tests/test_plot_from_txt.py
+++ b/tests/test_plot_from_txt.py
@@ -6,7 +6,7 @@ from analysis_types import AnalysisType
 from tabs.constants import (
     DEFAULT_UNITS,
     LEGEND_TITLE_TRANSLATIONS,
-    TITLES_SYMBOLS,
+    TITLE_TRANSLATIONS_BOLD,
 )
 from tabs.title_utils import format_signature
 
@@ -16,7 +16,7 @@ def test_extract_labels():
     assert x == "Время $\\mathit{\\mathit{t}}$, с"
     assert y == "Продольная сила $\\mathit{\\mathit{N}}$, Н"
     expected_title = format_signature(
-        f"{TITLES_SYMBOLS['Продольная сила']['Русский']}, {DEFAULT_UNITS['Продольная сила']}",
+        f"{TITLE_TRANSLATIONS_BOLD['Продольная сила']['Русский']}, {DEFAULT_UNITS['Продольная сила']}",
         bold=True,
     )
     assert title == expected_title


### PR DESCRIPTION
## Summary
- использовать словарь `TITLE_TRANSLATIONS_BOLD` при формировании заголовка графика из текстовых данных
- поправить тесты для нового словаря перевода

## Testing
- `pytest tests/test_plot_from_txt.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac08d66e9c832aa82005be83f8d417