### PR TITLE
Убрать единицы измерения из заголовка графика

### DIFF
--- a/plot_from_txt.py
+++ b/plot_from_txt.py
@@ -16,7 +16,6 @@ from tabs.functions_for_tab1.plotting import TitleProcessor
 from tabs.constants import (
     DEFAULT_UNITS,
     TITLE_TRANSLATIONS,
-    TITLE_TRANSLATIONS_BOLD,
     LEGEND_TITLE_TRANSLATIONS,
 )
 from topfolder_codec import decode_topfolder
@@ -61,8 +60,8 @@ def extract_labels(analysis_type: str) -> tuple[str, str, str]:
     )
     title_proc = TitleProcessor(
         graph_title,
-        combo_size=y_unit,
-        translations=TITLE_TRANSLATIONS_BOLD,
+        combo_size=Getter(""),
+        translations=TITLE_TRANSLATIONS,
         bold_math=True,
     )
 

--- a/tests/test_plot_from_txt.py
+++ b/tests/test_plot_from_txt.py
@@ -4,9 +4,8 @@ from unittest.mock import patch
 from plot_from_txt import extract_labels, plot_from_txt, plot_from_txt_files
 from analysis_types import AnalysisType
 from tabs.constants import (
-    DEFAULT_UNITS,
     LEGEND_TITLE_TRANSLATIONS,
-    TITLE_TRANSLATIONS_BOLD,
+    TITLE_TRANSLATIONS,
 )
 from tabs.title_utils import format_signature
 
@@ -16,7 +15,7 @@ def test_extract_labels():
     assert x == "Время $\\mathit{\\mathit{t}}$, с"
     assert y == "Продольная сила $\\mathit{\\mathit{N}}$, Н"
     expected_title = format_signature(
-        f"{TITLE_TRANSLATIONS_BOLD['Продольная сила']['Русский']}, {DEFAULT_UNITS['Продольная сила']}",
+        TITLE_TRANSLATIONS["Продольная сила"]["Русский"],
         bold=True,
     )
     assert title == expected_title


### PR DESCRIPTION
## Summary
- исключить размерность из автоматически формируемого заголовка
- использовать `TITLE_TRANSLATIONS` вместо `TITLE_TRANSLATIONS_BOLD`
- обновить тест `test_plot_from_txt` на новый формат заголовка

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac0cc54de0832a858877057a48bf75