### PR TITLE
Добавлены genselect target для beam и shell

### DIFF
--- a/tabs/function4tabs4/command_single.py
+++ b/tabs/function4tabs4/command_single.py
@@ -20,11 +20,13 @@ ETYPE_BY_ELEMENT: Dict[str, int] = {
 SELECT_TEMPLATES: Dict[Tuple[str, str | None], List[str]] = {
     ("element", "beam"): [
         "genselect clear all",
+        "genselect target beam",
         "genselect beam add beam {element_id}/0",
         "etype {etype} ;etime {etime}",
     ],
     ("element", "shell"): [
         "genselect clear all",
+        "genselect target shell",
         "genselect shell add shell {element_id}/0",
         "etype {etype} ;etime {etime}",
     ],

--- a/tests/test_command_single.py
+++ b/tests/test_command_single.py
@@ -17,6 +17,7 @@ def test_build_curve_commands_element():
     )
     assert cmds == [
         "genselect clear all",
+        "genselect target beam",
         "genselect beam add beam 7/0",
         f"etype {etype} ;etime {etime}",
         f'xyplot 1 savefile curve_file "C:\\proj\\curves\\pilon-element-beam\\{analysis}\\7.txt" 1 all',
@@ -80,4 +81,9 @@ def test_build_curve_commands_shell(analysis, etime):
         element_type="shell",
         element_id=3,
     )
-    assert cmds[2] == f"etype {etype} ;etime {etime}"
+    assert cmds[:3] == [
+        "genselect clear all",
+        "genselect target shell",
+        "genselect shell add shell 3/0",
+    ]
+    assert cmds[3] == f"etype {etype} ;etime {etime}"


### PR DESCRIPTION
## Summary
- добавлены команды `genselect target beam` и `genselect target shell` при генерации C-файлов
- обновлены тесты для новых команд выбора

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac1aaedabc832abe0e9007b28a713d