### PR TITLE
Добавлена поддержка числового префикса в именах папок

### DIFF
--- a/tests/test_topfolder_codec.py
+++ b/tests/test_topfolder_codec.py
@@ -29,9 +29,23 @@ def test_decode_node():
     assert decode_topfolder("uzli-node") == ("uzli", "node", None)
 
 
+def test_decode_with_prefix():
+    assert decode_topfolder("1-uzli-node") == ("uzli", "node", None)
+    assert decode_topfolder("10-pilon-element-beam") == (
+        "pilon",
+        "element",
+        "beam",
+    )
+
+
 def test_decode_invalid_format():
     with pytest.raises(ValueError):
         decode_topfolder("invalid")
+
+
+def test_decode_invalid_format_with_prefix():
+    with pytest.raises(ValueError):
+        decode_topfolder("1-invalid")
 
 
 def test_decode_invalid_entity():

--- a/tests/test_treeview_to_entity_nodes.py
+++ b/tests/test_treeview_to_entity_nodes.py
@@ -19,7 +19,7 @@ def test_treeview_to_entity_nodes_and_cfile(tmp_path):
     root.withdraw()
     tree = ttk.Treeview(root)
 
-    top_text = encode_topfolder("user", "node")
+    top_text = f"1-{encode_topfolder('user', 'node')}"
     top = tree.insert("", "end", text=top_text)
     analysis_type = ANALYSIS_TYPES_BEAM[0]
     analysis = tree.insert(top, "end", text=analysis_type)
@@ -50,9 +50,7 @@ def test_treeview_to_entity_nodes_and_cfile(tmp_path):
         top2 = tree2.insert(
             "",
             "end",
-            text=encode_topfolder(
-                entity.user_name, entity.entity_kind, entity.element_type
-            ),
+            text=f"1-{encode_topfolder(entity.user_name, entity.entity_kind, entity.element_type)}",
         )
         for analysis2 in entity.children:
             an_id = tree2.insert(top2, "end", text=analysis2.analysis_type)

--- a/topfolder_codec.py
+++ b/topfolder_codec.py
@@ -53,13 +53,29 @@ def encode_topfolder(user_name: str, entity_kind: str, element_type: Optional[st
 def decode_topfolder(folder_name: str) -> Tuple[str, str, Optional[str]]:
     """Decode folder name into components.
 
-    Returns a tuple ``(user_name, entity_kind, element_type)`` where
-    ``element_type`` может быть ``None``.
+    Допускается ведущий префикс вида ``"<число>-"``. Он игнорируется при
+    декодировании и используется только для уточнения сообщений об ошибках.
+
+    Returns
+    -------
+    tuple
+        ``(user_name, entity_kind, element_type)`` где ``element_type`` может
+        быть ``None``.
     """
+
+    prefix = None
+    if "-" in folder_name:
+        first, rest = folder_name.split("-", 1)
+        if first.isdigit():
+            prefix = first
+            folder_name = rest
+            if not folder_name:
+                raise ValueError("Неверный формат имени папки с префиксом.")
 
     parts = folder_name.split("-")
     if len(parts) not in (2, 3):
-        raise ValueError("Неверный формат имени папки.")
+        msg = "Неверный формат имени папки с префиксом." if prefix else "Неверный формат имени папки."
+        raise ValueError(msg)
 
     user_name = _validate_user_name(parts[0])
     entity_kind = parts[1]


### PR DESCRIPTION
## Summary
- поддержан необязательный числовой префикс при декодировании имен верхних папок
- добавлены проверки разборки имен с префиксом и без него
- учтен числовой префикс при восстановлении дерева сущностей

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac3a2dc388832a873c12d30ab83cbf