### PR TITLE
chore: strip numeric prefixes in curve scanning

### DIFF
--- a/curves_scan.py
+++ b/curves_scan.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Dict, List, Tuple
+import re
+
+
+def _clean_name(name: str) -> str:
+    """Удаляет ведущий числовой префикс вида ``<число>-``."""
+    return re.sub(r"^\d+-", "", name)
 
 
 def scan_curves(root_dir: Path | str) -> Tuple[Dict[str, Dict[str, List[str]]], List[str]]:
@@ -30,6 +36,7 @@ def scan_curves(root_dir: Path | str) -> Tuple[Dict[str, Dict[str, List[str]]], 
         return result, errors
 
     for top_path in top_dirs:
+        clean_top_name = _clean_name(top_path.name)
         analyses: Dict[str, List[str]] = {}
         had_subdirs = False
         for analysis_dir in top_path.iterdir():
@@ -42,19 +49,20 @@ def scan_curves(root_dir: Path | str) -> Tuple[Dict[str, Dict[str, List[str]]], 
                 if file_path.is_file() and file_path.suffix in {".png", ".txt"}:
                     files.append(str(file_path))
 
+            clean_analysis_name = _clean_name(analysis_dir.name)
             if files:
-                analyses[analysis_dir.name] = files
+                analyses[clean_analysis_name] = files
             else:
                 errors.append(
-                    f"Подпапка анализа '{analysis_dir.name}' в топ-папке "
-                    f"'{top_path.name}' не содержит файлов"
+                    f"Подпапка анализа '{clean_analysis_name}' в топ-папке "
+                    f"'{clean_top_name}' не содержит файлов"
                 )
 
         if analyses:
-            result[top_path.name] = analyses
+            result[clean_top_name] = analyses
         elif not had_subdirs:
             errors.append(
-                f"Топ-папка '{top_path.name}' не содержит подпапок анализов"
+                f"Топ-папка '{clean_top_name}' не содержит подпапок анализов"
             )
 
     return result, errors

--- a/tests/test_curves_scan.py
+++ b/tests/test_curves_scan.py
@@ -2,12 +2,12 @@ from curves_scan import scan_curves
 
 
 def test_scan_curves_collects_files(tmp_path):
-    pilon_analysis_dir = tmp_path / "pilon-element-beam" / "static"
+    pilon_analysis_dir = tmp_path / "01-pilon-element-beam" / "10-static"
     pilon_analysis_dir.mkdir(parents=True)
     (pilon_analysis_dir / "file.png").touch()
     (pilon_analysis_dir / "file.txt").touch()
 
-    uzli_analysis_dir = tmp_path / "uzli-node" / "dynamic"
+    uzli_analysis_dir = tmp_path / "2-uzli-node" / "3-dynamic"
     uzli_analysis_dir.mkdir(parents=True)
     (uzli_analysis_dir / "file.png").touch()
     (uzli_analysis_dir / "file.txt").touch()
@@ -42,9 +42,9 @@ def test_scan_curves_collects_files(tmp_path):
 
 def test_scan_curves_empty_or_missing(tmp_path):
     # Топ-папка с пустой подпапкой анализа
-    (tmp_path / "pilon-element-beam" / "static").mkdir(parents=True)
+    (tmp_path / "1-pilon-element-beam" / "2-static").mkdir(parents=True)
     # Топ-папка без подпапок анализа
-    (tmp_path / "uzli-node").mkdir()
+    (tmp_path / "02-uzli-node").mkdir()
 
     result, errors = scan_curves(tmp_path)
 


### PR DESCRIPTION
## Summary
- strip numeric prefixes from top and analysis folder names when scanning curves
- update curve scanning tests for prefix removal

## Testing
- `python -m pytest tests/test_curves_scan.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac3efb66b4832abfcd0525d2d92849