### PR TITLE
Сортировка графиков отчёта по числовому префиксу папки

### DIFF
--- a/report_docx.py
+++ b/report_docx.py
@@ -16,11 +16,26 @@ def _format_section_title(folder_name: str) -> str:
     return first
 
 
+def analysis_prefix(path: Path) -> int:
+    """Возвращает числовой префикс имени родительской папки PNG.
+
+    Извлекает ведущие цифры из имени директории, содержащей ``path``.
+    Если число не найдено, возвращает ``float('inf')``.
+
+    Примеры:
+        >>> analysis_prefix(Path('03-анализ/plot.png'))
+        3
+    """
+    match = re.match(r"^(\d+)", path.parent.name)
+    return int(match.group(1)) if match else float("inf")
+
+
 def build_report(curves_root: Path | str) -> Path:
     """Собирает отчет по PNG файлам в каталоге Curves.
 
     Для каждой топ-папки создаёт заголовок первого уровня и добавляет
     все найденные в ней графики (PNG) из вложенных каталогов.
+    Графики сортируются по числовому префиксу имени их родительской папки.
 
     Параметры:
         curves_root: Каталог с топ-папками.
@@ -37,7 +52,7 @@ def build_report(curves_root: Path | str) -> Path:
 
     for top_path in sorted(filter(Path.is_dir, root.iterdir()), key=_prefix):
         document.add_heading(_format_section_title(top_path.name), level=1)
-        for image_path in sorted(top_path.rglob("*.png")):
+        for image_path in sorted(top_path.rglob("*.png"), key=lambda p: analysis_prefix(p)):
             document.add_picture(str(image_path))
 
     output_path = root / "Report.docx"


### PR DESCRIPTION
## Summary
- Реализована функция `analysis_prefix` для получения числового префикса имени родительской папки PNG
- Графики в отчёте сортируются по этому префиксу
- Обновлено описание поведения `build_report`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac5f67d310832a9c6489a37d5a4112