### PR TITLE
Добавлены перемещения узлов в дереве

### DIFF
--- a/tabs/tab4.py
+++ b/tabs/tab4.py
@@ -282,6 +282,29 @@ def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:
         if new_name:
             tree.item(item, text=safe_name(new_name))
 
+    def move_up() -> None:
+        sel = tree.selection()
+        if not sel:
+            return
+        item = sel[0]
+        parent = tree.parent(item)
+        index = tree.index(item)
+        if index <= 0:
+            return
+        tree.move(item, parent, index - 1)
+
+    def move_down() -> None:
+        sel = tree.selection()
+        if not sel:
+            return
+        item = sel[0]
+        parent = tree.parent(item)
+        index = tree.index(item)
+        children = tree.get_children(parent)
+        if index >= len(children) - 1:
+            return
+        tree.move(item, parent, index + 1)
+
     def collapse_all() -> None:
         def _collapse(node: str) -> None:
             tree.item(node, open=False)
@@ -448,6 +471,10 @@ def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:
     ttk.Button(btn_frame, text="−", width=3, command=remove_node).pack(
         side=tk.LEFT, padx=5
     )
+    ttk.Button(btn_frame, text="↑", width=3, command=move_up).pack(side=tk.LEFT)
+    ttk.Button(btn_frame, text="↓", width=3, command=move_down).pack(
+        side=tk.LEFT, padx=5
+    )
     ttk.Button(btn_frame, text="Переименовать", command=rename_node).pack(side=tk.LEFT)
     ttk.Button(btn_frame, text="Свернуть всё", command=collapse_all).pack(
         side=tk.LEFT, padx=5
@@ -505,6 +532,8 @@ def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:
     tab4.add_node = add_node  # type: ignore[attr-defined]
     tab4.remove_node = remove_node  # type: ignore[attr-defined]
     tab4.rename_node = rename_node  # type: ignore[attr-defined]
+    tab4.move_up = move_up  # type: ignore[attr-defined]
+    tab4.move_down = move_down  # type: ignore[attr-defined]
 
     return tab4
 

--- a/tests/test_tab4_move.py
+++ b/tests/test_tab4_move.py
@@ -1,0 +1,69 @@
+import pytest
+import tkinter as tk
+from tkinter import ttk
+
+from tabs.tab4 import create_tab4
+
+
+def _create_app():
+    try:
+        root = tk.Tk()
+    except tk.TclError:
+        pytest.skip("Tkinter requires a display")
+    root.withdraw()
+    nb = ttk.Notebook(root)
+    tab = create_tab4(nb)
+    return root, tab
+
+
+def test_move_root_level():
+    root, tab = _create_app()
+    tree = tab.tree
+
+    a = tree.insert("", "end", text="a")
+    b = tree.insert("", "end", text="b")
+    c = tree.insert("", "end", text="c")
+
+    tree.selection_set(b)
+    tab.move_up()
+    assert tree.get_children("") == (b, a, c)
+
+    tree.selection_set(b)
+    tab.move_up()
+    assert tree.get_children("") == (b, a, c)
+
+    tree.selection_set(b)
+    tab.move_down()
+    assert tree.get_children("") == (a, b, c)
+
+    tree.selection_set(c)
+    tab.move_down()
+    assert tree.get_children("") == (a, b, c)
+    root.destroy()
+
+
+def test_move_second_level():
+    root, tab = _create_app()
+    tree = tab.tree
+
+    parent = tree.insert("", "end", text="top")
+    c1 = tree.insert(parent, "end", text="1")
+    c2 = tree.insert(parent, "end", text="2")
+    c3 = tree.insert(parent, "end", text="3")
+
+    tree.selection_set(c2)
+    tab.move_up()
+    assert tree.get_children(parent) == (c2, c1, c3)
+
+    tree.selection_set(c2)
+    tab.move_up()
+    assert tree.get_children(parent) == (c2, c1, c3)
+
+    tree.selection_set(c2)
+    tab.move_down()
+    assert tree.get_children(parent) == (c1, c2, c3)
+
+    tree.selection_set(c3)
+    tab.move_down()
+    assert tree.get_children(parent) == (c1, c2, c3)
+    root.destroy()


### PR DESCRIPTION
## Summary
- Реализовано перемещение выбранного узла дерева вверх/вниз
- Добавлены кнопки для смены порядка узлов в интерфейсе
- Покрыты тестами перемещения на верхнем и вложенном уровнях

## Testing
- `pytest tests/test_tab4_move.py tests/test_tab4_top_nodes.py tests/test_tab4_name.py tests/test_tab4_analysis_dialog.py`

------
https://chatgpt.com/codex/tasks/task_e_68aca708501c832a9717a2037ff9258a