### PR TITLE
Adjust plot editor layout to fit curve range controls

### DIFF
--- a/tabs/tab1.py
+++ b/tabs/tab1.py
@@ -714,7 +714,7 @@ def create_tab1(notebook: ttk.Notebook) -> None:
         x=ui_const.EDITOR_X,
         y=ui_const.EDITOR_Y,
         width=ui_const.PREVIEW_WIDTH,
-        height=ui_const.EDITOR_HEIGHT,
+        height=plot_editor.required_height,
     )
     plot_editor.place_forget()
 
@@ -760,14 +760,17 @@ def create_tab1(notebook: ttk.Notebook) -> None:
                 axis_manual_entries,
             )
             plot_editor.refresh()
+            editor_height = plot_editor.required_height
             if not editor_visible["shown"]:
                 plot_editor.place(
                     x=ui_const.EDITOR_X,
                     y=ui_const.EDITOR_Y,
                     width=ui_const.PREVIEW_WIDTH,
-                    height=ui_const.EDITOR_HEIGHT,
+                    height=editor_height,
                 )
                 editor_visible["shown"] = True
+            elif editor_height:
+                plot_editor.place_configure(height=editor_height)
             logger.info("График построен успешно")
         except ValueError as exc:
             logger.error("Ошибка построения графика", exc_info=True)

--- a/widgets/plot_editor.py
+++ b/widgets/plot_editor.py
@@ -65,6 +65,10 @@ class PlotEditor(ttk.Frame):
         self._rows: List[_RowWidgets] = []
         self._range_controls: List[_RangeWidgets] = []
         self._range_lock = False
+        self._cached_height = 0
+
+        self._line_styles = ["-", "--", "-.", ":"]
+        self._style_box_width = max(len(style) for style in self._line_styles) + 2
 
         self._init_range_styles()
 
@@ -133,6 +137,23 @@ class PlotEditor(ttk.Frame):
             self._build_range_controls(lines)
 
         self.apply_selected_palette()
+        self._update_size_hint()
+
+    # ------------------------------------------------------------------
+    def _update_size_hint(self) -> None:
+        """Запоминает требуемую высоту редактора после перестройки."""
+
+        self.update_idletasks()
+        self._cached_height = max(self.winfo_reqheight(), 1)
+
+    @property
+    def required_height(self) -> int:
+        """Возвращает актуальную высоту, необходимую для отображения всех элементов."""
+
+        if self._cached_height:
+            return self._cached_height
+        self.update_idletasks()
+        return max(self.winfo_reqheight(), 1)
 
     # ------------------------------------------------------------------
     def _append_row(self, line, index: int) -> None:
@@ -148,7 +169,11 @@ class PlotEditor(ttk.Frame):
             "<Button-1>", lambda _e, ln=line, lbl=colour_lbl: self._choose_colour(ln, lbl)
         )
 
-        style_box = ttk.Combobox(row_frame, values=["-", "--", "-.", ":"], width=5)
+        style_box = ttk.Combobox(
+            row_frame,
+            values=self._line_styles,
+            width=self._style_box_width,
+        )
         style_box.set(line.get_linestyle())
         style_box.pack(side=tk.LEFT, padx=5)
         style_box.bind(


### PR DESCRIPTION
## Summary
- shrink the curve type combobox to the minimal width based on available styles
- cache the plot editor height and expose it so the container can resize dynamically
- resize the plot editor panel when new curves are plotted to reveal all range sliders

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690cf21cc3c8832ab163056eede7141f