### PR TITLE
Adjust range slider to 0.01 percent precision

### DIFF
--- a/widgets/plot_editor.py
+++ b/widgets/plot_editor.py
@@ -316,8 +316,8 @@ class PlotEditor(ttk.Frame):
     ) -> None:
         if lower is None or upper is None:
             lower, upper = controls.slider.get()
-        controls.upper_value.set(f"До: {upper:.0f}%")
-        controls.lower_value.set(f"От: {lower:.0f}%")
+        controls.upper_value.set(f"До: {upper:.2f}%")
+        controls.lower_value.set(f"От: {lower:.2f}%")
 
     def _on_range_change(
         self, controls: _RangeWidgets, lower: float, upper: float

--- a/widgets/range_line.py
+++ b/widgets/range_line.py
@@ -51,9 +51,9 @@ class RangeLine(ttk.Frame):
 
     def set(self, lower=None, upper=None, notify=True):
         if lower is not None:
-            self.lower = max(self.from_, min(float(lower), self.to))
+            self.lower = self._quantize(self._clamp(lower))
         if upper is not None:
-            self.upper = max(self.from_, min(float(upper), self.to))
+            self.upper = self._quantize(self._clamp(upper))
         if self.lower > self.upper:
             self.lower, self.upper = self.upper, self.lower
         self._draw_dynamic()
@@ -98,6 +98,12 @@ class RangeLine(ttk.Frame):
         v = self.from_ + t * (self.to - self.from_)
         return max(self.from_, min(self.to, v))
 
+    def _clamp(self, value):
+        return max(self.from_, min(float(value), self.to))
+
+    def _quantize(self, value):
+        return round(float(value) * 100) / 100
+
     # --- события ---
     def _nearest_handle(self, x):
         xl = self._val2x(self.lower)
@@ -116,11 +122,11 @@ class RangeLine(ttk.Frame):
         self._dragging = None
 
     def _move_handle(self, which, x, notify=True):
-        v = self._x2val(x)
+        v = self._quantize(self._x2val(x))
         if which == "lower":
-            self.lower = min(v, self.upper)
+            self.lower = self._quantize(min(v, self.upper))
         else:
-            self.upper = max(v, self.lower)
+            self.upper = self._quantize(max(v, self.lower))
         self._draw_dynamic()
         if notify and self.command:
             self.command(self.lower, self.upper)


### PR DESCRIPTION
## Summary
- quantize range slider values to 0.01% increments for more precise control
- display slider labels with two decimal places to reflect the finer precision

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690deffeda00832a9069c01620b515d1)