### PR TITLE
Добавить поддержку nodal/none для разделов таба 4

### DIFF
--- a/analysis_types.py
+++ b/analysis_types.py
@@ -67,7 +67,7 @@ ANALYSIS_TYPES_SHELL: list[str] = [
 ANALYSIS_TYPES_BY_ELEMENT: dict[str | None, list[str]] = {
     "beam": ANALYSIS_TYPES_BEAM,
     "shell": ANALYSIS_TYPES_SHELL,
-    "node": [],
+    "nodal": [],
 }
 
 # Соответствие названия анализа номеру команды etime для разных типов элементов.

--- a/plot_from_txt.py
+++ b/plot_from_txt.py
@@ -155,7 +155,7 @@ def plot_from_txt_files(txt_files: list[str], analysis_type: str) -> str:
     try:
         _, entity_kind, _ = decode_topfolder(analysis_dir.parent.name)
     except ValueError:
-        entity_kind = "node"
+        entity_kind = "nodal"
     else:
         if entity_kind == "element":
             legend_key = "№ Элементов"

--- a/tabs/function4tabs4/command_all.py
+++ b/tabs/function4tabs4/command_all.py
@@ -35,6 +35,8 @@ def walk_tree_and_build_commands(
         names = list(top_folder_names)
 
     for section_index, (node, top_folder_name) in enumerate(zip(nodes, names)):
+        if node.entity_kind == "none":
+            continue
         for analysis_index, analysis in enumerate(node.children):
             dirname = None
             if analysis_folder_names is not None:

--- a/tabs/function4tabs4/command_single.py
+++ b/tabs/function4tabs4/command_single.py
@@ -35,7 +35,7 @@ SELECT_TEMPLATES: Dict[Tuple[str, str | None], List[str]] = {
         "genselect solid add solid {element_id}/0",
         "etype {etype} ;etime {etime}",
     ],
-    ("node", None): [
+    ("nodal", None): [
         "genselect clear all",
         "genselect node add node {element_id}",
     ],
@@ -70,14 +70,14 @@ def build_curve_commands(
         raise ValueError("analysis_type must be non-empty")
     if element_id <= 0:
         raise ValueError("element_id must be positive")
-    if entity_kind not in {"element", "node"}:
+    if entity_kind not in {"element", "nodal"}:
         raise ValueError("unknown entity_kind")
     if entity_kind == "element":
         if element_type not in {"beam", "shell", "solid"}:
             raise ValueError("invalid element_type for element")
     else:
         if element_type is not None:
-            raise ValueError("element_type must be None for node")
+            raise ValueError("element_type must be None for nodal")
 
     key = (entity_kind, element_type)
     try:

--- a/tabs/tab4.py
+++ b/tabs/tab4.py
@@ -69,10 +69,18 @@ class SectionDialog(simpledialog.Dialog):
             row=0, column=0, sticky="w", padx=5, pady=(5, 0)
         )
         self.name_var = tk.StringVar()
+        section_names = [
+            "Глобально",
+            "Узел",
+            "Колонна",
+            "Плита",
+            "Стена",
+            "Балка",
+        ]
         self.name_box = ttk.Combobox(
             master,
             textvariable=self.name_var,
-            values=["Колонна", "Плита", "Стена", "Балка"],
+            values=section_names,
             state="readonly",
         )
         self.name_box.grid(row=0, column=1, sticky="ew", padx=5, pady=(5, 0))
@@ -82,11 +90,10 @@ class SectionDialog(simpledialog.Dialog):
         ttk.Label(master, text="Тип").grid(
             row=1, column=0, sticky="w", padx=5, pady=(5, 0)
         )
-        self.entity_var = tk.StringVar(value="node")
+        self.entity_var = tk.StringVar(value="element")
         self.entity_box = ttk.Combobox(
             master,
             textvariable=self.entity_var,
-            values=("element", "node"),
             state="readonly",
         )
         self.entity_box.grid(row=1, column=1, sticky="ew", padx=5, pady=5)
@@ -108,9 +115,18 @@ class SectionDialog(simpledialog.Dialog):
             row=0, column=3, sticky="w", pady=(5, 0)
         )
 
+        def display_to_kind(display: str) -> str:
+            return "none" if display == "-" else display
+
+        def kind_to_display(kind: str) -> str:
+            return "-" if kind == "none" else kind
+
+        self._display_to_kind = display_to_kind
+        self._kind_to_display = kind_to_display
+
         def update_top(*_):
             name = safe_name(self.name_var.get())
-            kind = self.entity_var.get()
+            kind = display_to_kind(self.entity_var.get())
             elem = self.element_var.get() if kind == "element" else None
             try:
                 new_top = encode_topfolder(name, kind, elem)
@@ -119,7 +135,8 @@ class SectionDialog(simpledialog.Dialog):
             self.top_var.set(new_top)
 
         def on_entity_change(*_):
-            if self.entity_var.get() == "element":
+            kind = display_to_kind(self.entity_var.get())
+            if kind == "element":
                 self.element_label.grid(
                     row=2, column=0, sticky="w", padx=5, pady=(5, 0)
                 )
@@ -131,7 +148,27 @@ class SectionDialog(simpledialog.Dialog):
                 self.element_box.grid_remove()
             update_top()
 
-        self.name_var.trace_add("write", update_top)
+        def apply_name_rules(*_):
+            name = self.name_var.get()
+            if name == "Глобально":
+                values = ("-",)
+                state = "disabled"
+                default = "-"
+            elif name == "Узел":
+                values = ("nodal",)
+                state = "disabled"
+                default = "nodal"
+            else:
+                values = ("element", "nodal")
+                state = "readonly"
+                current = self.entity_var.get()
+                default = current if current in values else values[0]
+            self.entity_box.configure(values=values, state=state)
+            if self.entity_var.get() not in values or state == "disabled":
+                self.entity_var.set(default)
+            on_entity_change()
+
+        self.name_var.trace_add("write", apply_name_rules)
         self.entity_var.trace_add("write", on_entity_change)
         self.element_var.trace_add("write", update_top)
 
@@ -139,7 +176,7 @@ class SectionDialog(simpledialog.Dialog):
             try:
                 u, k, e = decode_topfolder(self._tree.item(self._item, "text"))
             except Exception:
-                u, k, e = "", "node", None
+                u, k, e = "", "nodal", None
             values = list(self.name_box["values"])
             if u in values:
                 self.name_box.current(values.index(u))
@@ -148,16 +185,17 @@ class SectionDialog(simpledialog.Dialog):
                 self.name_box["values"] = values
                 self.name_box.set(u)
             self.name_var.set(u)
-            self.entity_var.set(k)
+            apply_name_rules()
+            self.entity_var.set(kind_to_display(k))
             if e:
                 self.element_var.set(e)
 
-        on_entity_change()
+        apply_name_rules()
         return self.name_box
 
     def apply(self) -> None:  # pragma: no cover - UI code
         name = safe_name(self.name_var.get())
-        kind = self.entity_var.get()
+        kind = self._display_to_kind(self.entity_var.get())
         elem = self.element_var.get() if kind == "element" else None
         try:
             text = encode_topfolder(name, kind, elem)

--- a/tests/test_command_all.py
+++ b/tests/test_command_all.py
@@ -27,10 +27,10 @@ def test_walk_tree_and_build_commands(tmp_path):
     analysis = AnalysisType.TIME_AXIAL_FORCE.value
     entity = EntityNode(
         user_name="user",
-        entity_kind="node",
+        entity_kind="nodal",
         children=[AnalysisNode(analysis, children=[FileNode(1)])],
     )
-    numbered = f"1-{encode_topfolder('user', 'node')}"
+    numbered = f"1-{encode_topfolder('user', 'nodal')}"
     folder_map = {(0, 0): f"1-{analysis}"}
     commands = walk_tree_and_build_commands(
         [entity],
@@ -49,3 +49,13 @@ def test_walk_tree_and_build_commands(tmp_path):
         "xyplot 1 donemenu",
         "deletewin 1",
     ]
+
+
+def test_walk_tree_and_build_commands_skips_none(tmp_path):
+    entity = EntityNode(
+        user_name="global",
+        entity_kind="none",
+        children=[AnalysisNode("static", children=[FileNode(1)])],
+    )
+    commands = walk_tree_and_build_commands([entity], base_project_dir=tmp_path)
+    assert commands == []

--- a/tests/test_command_single.py
+++ b/tests/test_command_single.py
@@ -26,20 +26,20 @@ def test_build_curve_commands_element():
     ]
 
 
-def test_build_curve_commands_node():
+def test_build_curve_commands_nodal():
     analysis = AnalysisType.TIME_AXIAL_FORCE.value
     cmds = build_curve_commands(
         base_project_dir="C:\\proj",
-        top_folder_name="uzli-node",
+        top_folder_name="uzli-nodal",
         analysis_type=analysis,
-        entity_kind="node",
+        entity_kind="nodal",
         element_type=None,
         element_id=15,
     )
     assert cmds == [
         "genselect clear all",
         "genselect node add node 15",
-        f'xyplot 1 savefile curve_file "C:\\proj\\curves\\uzli-node\\{analysis}\\15.txt" 1 all',
+        f'xyplot 1 savefile curve_file "C:\\proj\\curves\\uzli-nodal\\{analysis}\\15.txt" 1 all',
         "xyplot 1 donemenu",
         "deletewin 1",
     ]
@@ -49,15 +49,15 @@ def test_build_curve_commands_custom_dirname():
     analysis = AnalysisType.TIME_AXIAL_FORCE.value
     cmds = build_curve_commands(
         base_project_dir="C:\\proj",
-        top_folder_name="uzli-node",
+        top_folder_name="uzli-nodal",
         analysis_type=analysis,
-        entity_kind="node",
+        entity_kind="nodal",
         element_type=None,
         element_id=15,
         analysis_dirname="1-custom",
     )
     assert cmds[2] == (
-        'xyplot 1 savefile curve_file "C:\\proj\\curves\\uzli-node\\1-custom\\15.txt" 1 all'
+        'xyplot 1 savefile curve_file "C:\\proj\\curves\\uzli-nodal\\1-custom\\15.txt" 1 all'
     )
 
 
@@ -68,16 +68,16 @@ def test_build_curve_commands_custom_dirname():
         {"analysis_type": "unsupported"},
         {"entity_kind": "unknown"},
         {"entity_kind": "element", "element_type": "foo"},
-        {"entity_kind": "node", "element_type": "beam"},
+        {"entity_kind": "nodal", "element_type": "beam"},
         {"element_id": 0},
     ],
 )
 def test_build_curve_commands_invalid(kwargs):
     base_args = dict(
         base_project_dir="C:\\proj",
-        top_folder_name="p-node",
+        top_folder_name="p-nodal",
         analysis_type=AnalysisType.TIME_AXIAL_FORCE.value,
-        entity_kind="node",
+        entity_kind="nodal",
         element_type=None,
         element_id=1,
     )

--- a/tests/test_curves_scan.py
+++ b/tests/test_curves_scan.py
@@ -7,7 +7,7 @@ def test_scan_curves_collects_files(tmp_path):
     (pilon_analysis_dir / "file.png").touch()
     (pilon_analysis_dir / "file.txt").touch()
 
-    uzli_analysis_dir = tmp_path / "2-uzli-node" / "3-dynamic"
+    uzli_analysis_dir = tmp_path / "2-uzli-nodal" / "3-dynamic"
     uzli_analysis_dir.mkdir(parents=True)
     (uzli_analysis_dir / "file.png").touch()
     (uzli_analysis_dir / "file.txt").touch()
@@ -19,7 +19,7 @@ def test_scan_curves_collects_files(tmp_path):
                 str(pilon_analysis_dir / "file.txt"),
             ],
         },
-        "2-uzli-node": {
+        "2-uzli-nodal": {
             "dynamic": [
                 str(uzli_analysis_dir / "file.png"),
                 str(uzli_analysis_dir / "file.txt"),
@@ -44,7 +44,7 @@ def test_scan_curves_empty_or_missing(tmp_path):
     # Топ-папка с пустой подпапкой анализа
     (tmp_path / "1-pilon-element-beam" / "2-static").mkdir(parents=True)
     # Топ-папка без подпапок анализа
-    (tmp_path / "02-uzli-node").mkdir()
+    (tmp_path / "02-uzli-nodal").mkdir()
 
     result, errors = scan_curves(tmp_path)
 
@@ -52,7 +52,7 @@ def test_scan_curves_empty_or_missing(tmp_path):
     assert sorted(errors) == sorted(
         [
             "Подпапка анализа 'static' в топ-папке '1-pilon-element-beam' не содержит файлов",
-            "Топ-папка '02-uzli-node' не содержит подпапок анализов",
+            "Топ-папка '02-uzli-nodal' не содержит подпапок анализов",
         ]
     )
 

--- a/tests/test_entitynode_add_analysis.py
+++ b/tests/test_entitynode_add_analysis.py
@@ -5,20 +5,20 @@ from tree_schema import EntityNode
 
 
 def test_add_analysis_valid():
-    node = EntityNode(user_name="user", entity_kind="node")
+    node = EntityNode(user_name="user", entity_kind="nodal")
     analysis = node.add_analysis(AnalysisType.TIME_AXIAL_FORCE.value)
     assert analysis in node.children
     assert analysis.analysis_type == AnalysisType.TIME_AXIAL_FORCE.value
 
 
 def test_add_analysis_invalid():
-    node = EntityNode(user_name="user", entity_kind="node")
+    node = EntityNode(user_name="user", entity_kind="nodal")
     with pytest.raises(ValueError):
         node.add_analysis("неизвестный тип")
 
 
 def test_add_analysis_duplicate():
-    node = EntityNode(user_name="user", entity_kind="node")
+    node = EntityNode(user_name="user", entity_kind="nodal")
     node.add_analysis(AnalysisType.TIME_AXIAL_FORCE.value)
     with pytest.raises(ValueError):
         node.add_analysis(AnalysisType.TIME_AXIAL_FORCE.value)

--- a/tests/test_gui_bridge.py
+++ b/tests/test_gui_bridge.py
@@ -64,7 +64,7 @@ def test_tree_from_gui_basic():
 def test_tree_from_gui_duplicate_ids():
     tree = FakeTreeWidget([
         FakeItem("user", [
-            FakeItem("node", [
+            FakeItem("nodal", [
                 FakeItem("static", [FakeItem("1"), FakeItem("1")])
             ])
         ])
@@ -76,7 +76,7 @@ def test_tree_from_gui_duplicate_ids():
 def test_tree_from_gui_invalid_analysis():
     tree = FakeTreeWidget([
         FakeItem("user", [
-            FakeItem("node", [
+            FakeItem("nodal", [
                 FakeItem("unknown", [FakeItem("1")])
             ])
         ])

--- a/tests/test_tab4_top_nodes.py
+++ b/tests/test_tab4_top_nodes.py
@@ -25,7 +25,7 @@ def test_add_rename_remove_top_nodes(monkeypatch):
 
     start = len(tree.get_children())
 
-    add_params = {"name": "top", "kind": "node", "elem": None}
+    add_params = {"name": "top", "kind": "nodal", "elem": None}
     rename_params = {"name": "new", "kind": "element", "elem": "beam"}
 
     def _make_dialog(params):

--- a/tests/test_topfolder_codec.py
+++ b/tests/test_topfolder_codec.py
@@ -7,13 +7,17 @@ def test_encode_element():
     assert encode_topfolder("pilon", "element", "beam") == "pilon-element-beam"
 
 
-def test_encode_node():
-    assert encode_topfolder("uzli", "node") == "uzli-node"
+def test_encode_nodal():
+    assert encode_topfolder("uzli", "nodal") == "uzli-nodal"
+
+
+def test_encode_none():
+    assert encode_topfolder("global", "none") == "global-none"
 
 
 def test_encode_invalid_user():
     with pytest.raises(ValueError):
-        encode_topfolder("", "node")
+        encode_topfolder("", "nodal")
 
 
 def test_encode_missing_element_type():
@@ -25,12 +29,16 @@ def test_decode_element():
     assert decode_topfolder("pilon-element-beam") == ("pilon", "element", "beam")
 
 
-def test_decode_node():
-    assert decode_topfolder("uzli-node") == ("uzli", "node", None)
+def test_decode_nodal():
+    assert decode_topfolder("uzli-nodal") == ("uzli", "nodal", None)
+
+
+def test_decode_none():
+    assert decode_topfolder("global-none") == ("global", "none", None)
 
 
 def test_decode_with_prefix():
-    assert decode_topfolder("1-uzli-node") == ("uzli", "node", None)
+    assert decode_topfolder("1-uzli-nodal") == ("uzli", "nodal", None)
     assert decode_topfolder("10-pilon-element-beam") == (
         "pilon",
         "element",

--- a/tests/test_treeview_to_entity_nodes.py
+++ b/tests/test_treeview_to_entity_nodes.py
@@ -19,7 +19,7 @@ def test_treeview_to_entity_nodes_and_cfile(tmp_path):
     root.withdraw()
     tree = ttk.Treeview(root)
 
-    top_text = f"1-{encode_topfolder('user', 'node')}"
+    top_text = f"1-{encode_topfolder('user', 'nodal')}"
     top = tree.insert("", "end", text=top_text)
     analysis_type = ANALYSIS_TYPES_BEAM[0]
     analysis = tree.insert(top, "end", text=analysis_type)
@@ -29,7 +29,7 @@ def test_treeview_to_entity_nodes_and_cfile(tmp_path):
     expected = [
         EntityNode(
             user_name="user",
-            entity_kind="node",
+            entity_kind="nodal",
             element_type=None,
             children=[
                 AnalysisNode(analysis_type=analysis_type, children=[FileNode(id=1)])
@@ -58,7 +58,7 @@ def test_treeview_to_entity_nodes_and_cfile(tmp_path):
                 tree2.insert(an_id, "end", text=str(file.id))
     assert treeview_to_entity_nodes(tree2) == expected
 
-    numbered = [f"1-{encode_topfolder('user', 'node')}" for _ in nodes]
+    numbered = [f"1-{encode_topfolder('user', 'nodal')}" for _ in nodes]
     commands = walk_tree_and_build_commands(
         nodes, tmp_path, top_folder_names=numbered
     )

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -22,7 +22,8 @@ def test_unique_names_duplicate():
 
 
 def test_validate_entity_kind():
-    assert validate_entity({"entity_kind": "node"}) == {"entity_kind": "node"}
+    assert validate_entity({"entity_kind": "nodal"}) == {"entity_kind": "nodal"}
+    assert validate_entity({"entity_kind": "none"}) == {"entity_kind": "none"}
     with pytest.raises(ValidationError):
         validate_entity({"entity_kind": "element"})
     assert validate_entity({"entity_kind": "element", "element_type": "shell"}) == {

--- a/topfolder_codec.py
+++ b/topfolder_codec.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Optional, Tuple
 
 # Allowed kinds of entities and element types.
-ENTITY_KINDS = {"element", "node"}
+ENTITY_KINDS = {"element", "nodal", "none"}
 ELEMENT_TYPES = {"beam", "shell", "solid", "spring", "mass", "rigid"}
 
 # Characters that must not appear in user name.
@@ -45,9 +45,12 @@ def encode_topfolder(user_name: str, entity_kind: str, element_type: Optional[st
             raise ValueError("Недопустимый тип элемента.")
         return f"{user_name}-{entity_kind}-{element_type}"
 
-    if element_type is not None:
-        raise ValueError("Тип элемента можно указывать только для 'element'.")
-    return f"{user_name}-{entity_kind}"
+    if entity_kind in {"nodal", "none"}:
+        if element_type is not None:
+            raise ValueError("Тип элемента можно указывать только для 'element'.")
+        return f"{user_name}-{entity_kind}"
+
+    raise ValueError("Недопустимый тип сущности.")
 
 
 def decode_topfolder(folder_name: str) -> Tuple[str, str, Optional[str]]:

--- a/tree_schema.py
+++ b/tree_schema.py
@@ -5,13 +5,13 @@ from typing import Literal
 
 from analysis_types import ANALYSIS_TYPES
 
-EntityKind = Literal["element", "node"]
+EntityKind = Literal["element", "nodal", "none"]
 ElementType = Literal["beam", "shell", "solid"]
 
 
 @dataclass
 class FileNode:
-    """Leaf node that represents a particular element or node."""
+    """Leaf node that represents a particular element or nodal point."""
 
     id: int
 
@@ -46,7 +46,7 @@ class AnalysisNode:
 
 @dataclass
 class EntityNode:
-    """Top-level node representing an entity (element or node)."""
+    """Top-level node representing an entity (element, nodal or none)."""
 
     user_name: str
     entity_kind: EntityKind

--- a/validators.py
+++ b/validators.py
@@ -22,8 +22,10 @@ def ensure_unique_names(items: Iterable, key: str = "name"):
 def validate_entity(data: dict):
     """Проверяет корректность описания сущности."""
     kind = data.get("entity_kind")
-    if kind not in {"element", "node"}:
-        raise ValidationError("entity_kind может быть только 'element' или 'node'")
+    if kind not in {"element", "nodal", "none"}:
+        raise ValidationError(
+            "entity_kind может быть только 'element', 'nodal' или 'none'"
+        )
     if kind == "element" and not data.get("element_type"):
         raise ValidationError("Для 'element' необходимо указать element_type")
     return data


### PR DESCRIPTION
## Summary
- расширил кодировщик topfolder и структуру EntityNode для новых типов nodal и none
- обновил диалог разделов вкладки 4 и обработчики команд для жёсткой привязки типов "Глобально" и "Узел"
- скорректировал сопутствующие утилиты и тесты под новые значения

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e2d9f488c832a9a4f0694f3a398aa)