### PR TITLE
Добавлена поддержка глобальных и узловых анализов в автокривых

### DIFF
--- a/analysis_types.py
+++ b/analysis_types.py
@@ -24,6 +24,25 @@ class AnalysisType(str, Enum):
     TIME_BENDING_MOMENT_MX = "Время - Изгибающий момент Mx(п)"
     TIME_BENDING_MOMENT_MY = "Время - Изгибающий момент My(п)"
     TIME_BENDING_MOMENT_MXY = "Время - Изгибающий момент Mxy(п)"
+    TIME_GLOBAL_KINETIC_ENERGY = "Время - Кинетическая энергия"
+    TIME_GLOBAL_POTENTIAL_ENERGY = "Время - Потенциальная энергия"
+    TIME_GLOBAL_TOTAL_ENERGY = "Время - Полная энергия"
+    TIME_NODE_COORDINATE_X = "Время - Координата X"
+    TIME_NODE_COORDINATE_Y = "Время - Координата Y"
+    TIME_NODE_COORDINATE_Z = "Время - Координата Z"
+    TIME_NODE_COORDINATE_TOTAL = "Время - Суммарная координата (модуль)"
+    TIME_NODE_DISPLACEMENT_X = "Время - Перемещение по X"
+    TIME_NODE_DISPLACEMENT_Y = "Время - Перемещение по Y"
+    TIME_NODE_DISPLACEMENT_Z = "Время - Перемещение по Z"
+    TIME_NODE_DISPLACEMENT_TOTAL = "Время - Результирующее перемещение (модуль)"
+    TIME_NODE_VELOCITY_X = "Время - Скорость по X"
+    TIME_NODE_VELOCITY_Y = "Время - Скорость по Y"
+    TIME_NODE_VELOCITY_Z = "Время - Скорость по Z"
+    TIME_NODE_VELOCITY_TOTAL = "Время - Результирующая скорость (модуль)"
+    TIME_NODE_ACCELERATION_X = "Время - Ускорение по X"
+    TIME_NODE_ACCELERATION_Y = "Время - Ускорение по Y"
+    TIME_NODE_ACCELERATION_Z = "Время - Ускорение по Z"
+    TIME_NODE_ACCELERATION_TOTAL = "Время - Результирующее ускорение (модуль)"
 
     @classmethod
     def list(cls) -> list[str]:
@@ -63,16 +82,43 @@ ANALYSIS_TYPES_SHELL: list[str] = [
     AnalysisType.TIME_BENDING_MOMENT_MXY.value,
 ]
 
-# Карта доступных типов анализа для разных типов элементов.
-ANALYSIS_TYPES_BY_ELEMENT: dict[str | None, list[str]] = {
-    "beam": ANALYSIS_TYPES_BEAM,
-    "shell": ANALYSIS_TYPES_SHELL,
-    "nodal": [],
+ANALYSIS_TYPES_GLOBAL: list[str] = [
+    AnalysisType.TIME_GLOBAL_KINETIC_ENERGY.value,
+    AnalysisType.TIME_GLOBAL_POTENTIAL_ENERGY.value,
+    AnalysisType.TIME_GLOBAL_TOTAL_ENERGY.value,
+]
+
+ANALYSIS_TYPES_NODAL: list[str] = [
+    AnalysisType.TIME_NODE_COORDINATE_X.value,
+    AnalysisType.TIME_NODE_COORDINATE_Y.value,
+    AnalysisType.TIME_NODE_COORDINATE_Z.value,
+    AnalysisType.TIME_NODE_COORDINATE_TOTAL.value,
+    AnalysisType.TIME_NODE_DISPLACEMENT_X.value,
+    AnalysisType.TIME_NODE_DISPLACEMENT_Y.value,
+    AnalysisType.TIME_NODE_DISPLACEMENT_Z.value,
+    AnalysisType.TIME_NODE_DISPLACEMENT_TOTAL.value,
+    AnalysisType.TIME_NODE_VELOCITY_X.value,
+    AnalysisType.TIME_NODE_VELOCITY_Y.value,
+    AnalysisType.TIME_NODE_VELOCITY_Z.value,
+    AnalysisType.TIME_NODE_VELOCITY_TOTAL.value,
+    AnalysisType.TIME_NODE_ACCELERATION_X.value,
+    AnalysisType.TIME_NODE_ACCELERATION_Y.value,
+    AnalysisType.TIME_NODE_ACCELERATION_Z.value,
+    AnalysisType.TIME_NODE_ACCELERATION_TOTAL.value,
+]
+
+# Карта доступных типов анализа для разных комбинаций сущностей.
+ANALYSIS_TYPES_BY_ENTITY: dict[tuple[str, str | None], list[str]] = {
+    ("element", "beam"): ANALYSIS_TYPES_BEAM,
+    ("element", "shell"): ANALYSIS_TYPES_SHELL,
+    ("element", "solid"): [],
+    ("nodal", None): ANALYSIS_TYPES_NODAL,
+    ("none", None): ANALYSIS_TYPES_GLOBAL,
 }
 
 # Соответствие названия анализа номеру команды etime для разных типов элементов.
-ANALYSIS_TYPE_CODES: dict[str, dict[str, int]] = {
-    "beam": {
+ANALYSIS_TYPE_CODES: dict[tuple[str, str | None], dict[str, int]] = {
+    ("element", "beam"): {
         AnalysisType.TIME_AXIAL_FORCE.value: 1,
         AnalysisType.TIME_SHEAR_FORCE_Y.value: 2,
         AnalysisType.TIME_SHEAR_FORCE_Z.value: 3,
@@ -86,7 +132,7 @@ ANALYSIS_TYPE_CODES: dict[str, dict[str, int]] = {
         AnalysisType.TIME_ELONGATION.value: 11,
         AnalysisType.TIME_STRESS_INTENSITY.value: 12,
     },
-    "shell": {
+    ("element", "shell"): {
         AnalysisType.TIME_NORMAL_STRESS_X.value: 1,
         AnalysisType.TIME_NORMAL_STRESS_Y.value: 2,
         AnalysisType.TIME_NORMAL_STRESS_Z.value: 3,
@@ -100,6 +146,29 @@ ANALYSIS_TYPE_CODES: dict[str, dict[str, int]] = {
         AnalysisType.TIME_BENDING_MOMENT_MY.value: 27,
         AnalysisType.TIME_BENDING_MOMENT_MXY.value: 28,
     },
+    ("nodal", None): {
+        AnalysisType.TIME_NODE_COORDINATE_X.value: 1,
+        AnalysisType.TIME_NODE_COORDINATE_Y.value: 2,
+        AnalysisType.TIME_NODE_COORDINATE_Z.value: 3,
+        AnalysisType.TIME_NODE_COORDINATE_TOTAL.value: 4,
+        AnalysisType.TIME_NODE_DISPLACEMENT_X.value: 5,
+        AnalysisType.TIME_NODE_DISPLACEMENT_Y.value: 6,
+        AnalysisType.TIME_NODE_DISPLACEMENT_Z.value: 7,
+        AnalysisType.TIME_NODE_DISPLACEMENT_TOTAL.value: 8,
+        AnalysisType.TIME_NODE_VELOCITY_X.value: 9,
+        AnalysisType.TIME_NODE_VELOCITY_Y.value: 10,
+        AnalysisType.TIME_NODE_VELOCITY_Z.value: 11,
+        AnalysisType.TIME_NODE_VELOCITY_TOTAL.value: 12,
+        AnalysisType.TIME_NODE_ACCELERATION_X.value: 13,
+        AnalysisType.TIME_NODE_ACCELERATION_Y.value: 14,
+        AnalysisType.TIME_NODE_ACCELERATION_Z.value: 15,
+        AnalysisType.TIME_NODE_ACCELERATION_TOTAL.value: 16,
+    },
+    ("none", None): {
+        AnalysisType.TIME_GLOBAL_KINETIC_ENERGY.value: 1,
+        AnalysisType.TIME_GLOBAL_POTENTIAL_ENERGY.value: 2,
+        AnalysisType.TIME_GLOBAL_TOTAL_ENERGY.value: 3,
+    },
 }
 
 __all__ = [
@@ -107,6 +176,8 @@ __all__ = [
     "ANALYSIS_TYPES",
     "ANALYSIS_TYPES_BEAM",
     "ANALYSIS_TYPES_SHELL",
-    "ANALYSIS_TYPES_BY_ELEMENT",
+    "ANALYSIS_TYPES_GLOBAL",
+    "ANALYSIS_TYPES_NODAL",
+    "ANALYSIS_TYPES_BY_ENTITY",
     "ANALYSIS_TYPE_CODES",
 ]

--- a/tabs/function4tabs4/command_all.py
+++ b/tabs/function4tabs4/command_all.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Iterable, List, Mapping, Sequence, Tuple
 
-from .command_single import build_command, build_curve_commands
+from .command_single import (
+    build_command,
+    build_curve_commands,
+    build_global_curve_commands,
+)
 from .tree_schema import Tree
 from topfolder_codec import encode_topfolder
 from tree_schema import EntityNode
@@ -35,12 +39,21 @@ def walk_tree_and_build_commands(
         names = list(top_folder_names)
 
     for section_index, (node, top_folder_name) in enumerate(zip(nodes, names)):
-        if node.entity_kind == "none":
-            continue
         for analysis_index, analysis in enumerate(node.children):
             dirname = None
             if analysis_folder_names is not None:
                 dirname = analysis_folder_names.get((section_index, analysis_index))
+            if node.entity_kind == "none":
+                commands.extend(
+                    build_global_curve_commands(
+                        str(base_dir),
+                        top_folder_name,
+                        analysis.analysis_type,
+                        curves_dirname,
+                        dirname,
+                    )
+                )
+                continue
             for file_node in analysis.children:
                 commands.extend(
                     build_curve_commands(

--- a/tabs/function4tabs4/command_single.py
+++ b/tabs/function4tabs4/command_single.py
@@ -38,8 +38,14 @@ SELECT_TEMPLATES: Dict[Tuple[str, str | None], List[str]] = {
     ("nodal", None): [
         "genselect clear all",
         "genselect node add node {element_id}",
+        "ntime {ntime}",
     ],
 }
+
+GLOBAL_TEMPLATE: List[str] = [
+    "genselect clear all",
+    "gtime {gtime}",
+]
 
 
 def build_command(name: str, props: Dict[str, Any]) -> str:
@@ -93,16 +99,19 @@ def build_curve_commands(
             raise ValueError("unsupported element_type") from exc
 
     try:
-        if element_type is None:
-            etime = ANALYSIS_TYPE_CODES["beam"][analysis_type]
-        else:
-            etime = ANALYSIS_TYPE_CODES[element_type][analysis_type]
+        code = ANALYSIS_TYPE_CODES[key][analysis_type]
     except KeyError as exc:
         raise ValueError("unsupported analysis_type") from exc
 
-    select_cmds = [
-        cmd.format(element_id=element_id, etype=etype, etime=etime) for cmd in template
-    ]
+    format_args: Dict[str, Any] = {"element_id": element_id}
+    if etype is not None:
+        format_args["etype"] = etype
+    if entity_kind == "element":
+        format_args["etime"] = code
+    else:
+        format_args["ntime"] = code
+
+    select_cmds = [cmd.format(**format_args) for cmd in template]
 
     curve_path = PureWindowsPath(
         base_project_dir,
@@ -121,4 +130,41 @@ def build_curve_commands(
     return select_cmds + save_cmds
 
 
-__all__ = ["build_command", "build_curve_commands"]
+def build_global_curve_commands(
+    base_project_dir: str,
+    top_folder_name: str,
+    analysis_type: str,
+    curves_dirname: str = "curves",
+    analysis_dirname: str | None = None,
+) -> List[str]:
+    """Построить команды для глобальных графиков энергий."""
+
+    if not analysis_type:
+        raise ValueError("analysis_type must be non-empty")
+
+    key = ("none", None)
+    try:
+        gtime = ANALYSIS_TYPE_CODES[key][analysis_type]
+    except KeyError as exc:
+        raise ValueError("unsupported analysis_type") from exc
+
+    select_cmds = [cmd.format(gtime=gtime) for cmd in GLOBAL_TEMPLATE]
+
+    curve_path = PureWindowsPath(
+        base_project_dir,
+        curves_dirname,
+        top_folder_name,
+        analysis_dirname or analysis_type,
+        f"{gtime}.txt",
+    )
+
+    save_cmds = [
+        f'xyplot 1 savefile curve_file "{curve_path}" 1 all',
+        "xyplot 1 donemenu",
+        "deletewin 1",
+    ]
+
+    return select_cmds + save_cmds
+
+
+__all__ = ["build_command", "build_curve_commands", "build_global_curve_commands"]

--- a/tabs/tab4.py
+++ b/tabs/tab4.py
@@ -19,7 +19,7 @@ from tree_schema import AnalysisNode, EntityNode, FileNode
 from ui import constants as ui_const
 from widgets import create_text, select_path
 from curves_pipeline import build_curves_report
-from analysis_types import ANALYSIS_TYPES_BY_ELEMENT
+from analysis_types import ANALYSIS_TYPES_BY_ENTITY
 
 
 class AnalysisTypeDialog(simpledialog.Dialog):
@@ -283,12 +283,12 @@ def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:
         parent = tree.parent(item)
 
         try:
-            _, _, element_type = decode_topfolder(tree.item(item, "text"))
+            _, entity_kind, element_type = decode_topfolder(tree.item(item, "text"))
         except Exception:
-            element_type = None
+            entity_kind, element_type = "element", None
 
         if parent == "":
-            values = ANALYSIS_TYPES_BY_ELEMENT.get(element_type, [])
+            values = ANALYSIS_TYPES_BY_ENTITY.get((entity_kind, element_type), [])
             dlg = AnalysisTypeDialog(
                 tab4, title="Выбор типа анализа", values=values
             )
@@ -298,6 +298,17 @@ def create_tab4(notebook: ttk.Notebook) -> ttk.Frame:
             return
 
         if tree.parent(parent) == "":
+            try:
+                _, parent_kind, _ = decode_topfolder(tree.item(parent, "text"))
+            except Exception:
+                parent_kind = "element"
+            if parent_kind == "none":
+                messagebox.showinfo(
+                    "Добавление узлов",
+                    "Для глобальных анализов не требуются номера узлов/элементов.",
+                    parent=tab4,
+                )
+                return
             number = simpledialog.askstring(
                 "Номер элемента", "Введите номер", parent=tab4
             )

--- a/tests/test_command_all.py
+++ b/tests/test_command_all.py
@@ -24,7 +24,7 @@ def test_collect_commands():
 
 
 def test_walk_tree_and_build_commands(tmp_path):
-    analysis = AnalysisType.TIME_AXIAL_FORCE.value
+    analysis = AnalysisType.TIME_NODE_DISPLACEMENT_X.value
     entity = EntityNode(
         user_name="user",
         entity_kind="nodal",
@@ -45,17 +45,24 @@ def test_walk_tree_and_build_commands(tmp_path):
     assert commands == [
         "genselect clear all",
         "genselect node add node 1",
+        "ntime 5",
         f'xyplot 1 savefile curve_file "{expected_path}" 1 all',
         "xyplot 1 donemenu",
         "deletewin 1",
     ]
 
 
-def test_walk_tree_and_build_commands_skips_none(tmp_path):
+def test_walk_tree_and_build_commands_handles_global(tmp_path):
     entity = EntityNode(
         user_name="global",
         entity_kind="none",
-        children=[AnalysisNode("static", children=[FileNode(1)])],
+        children=[
+            AnalysisNode(AnalysisType.TIME_GLOBAL_KINETIC_ENERGY.value, children=[])
+        ],
     )
-    commands = walk_tree_and_build_commands([entity], base_project_dir=tmp_path)
-    assert commands == []
+    numbered = f"1-{encode_topfolder('global', 'none')}"
+    commands = walk_tree_and_build_commands(
+        [entity], base_project_dir=tmp_path, top_folder_names=[numbered]
+    )
+    assert commands[0] == "genselect clear all"
+    assert commands[1] == "gtime 1"

--- a/tests/test_command_single.py
+++ b/tests/test_command_single.py
@@ -1,12 +1,16 @@
 import pytest
 from analysis_types import AnalysisType, ANALYSIS_TYPE_CODES
-from tabs.function4tabs4.command_single import build_curve_commands, ETYPE_BY_ELEMENT
+from tabs.function4tabs4.command_single import (
+    build_curve_commands,
+    build_global_curve_commands,
+    ETYPE_BY_ELEMENT,
+)
 
 
 def test_build_curve_commands_element():
     analysis = AnalysisType.TIME_AXIAL_FORCE.value
     etype = ETYPE_BY_ELEMENT["beam"]
-    etime = ANALYSIS_TYPE_CODES["beam"][analysis]
+    etime = ANALYSIS_TYPE_CODES[("element", "beam")][analysis]
     cmds = build_curve_commands(
         base_project_dir="C:\\proj",
         top_folder_name="pilon-element-beam",
@@ -27,7 +31,8 @@ def test_build_curve_commands_element():
 
 
 def test_build_curve_commands_nodal():
-    analysis = AnalysisType.TIME_AXIAL_FORCE.value
+    analysis = AnalysisType.TIME_NODE_DISPLACEMENT_X.value
+    ntime = ANALYSIS_TYPE_CODES[("nodal", None)][analysis]
     cmds = build_curve_commands(
         base_project_dir="C:\\proj",
         top_folder_name="uzli-nodal",
@@ -39,6 +44,7 @@ def test_build_curve_commands_nodal():
     assert cmds == [
         "genselect clear all",
         "genselect node add node 15",
+        f"ntime {ntime}",
         f'xyplot 1 savefile curve_file "C:\\proj\\curves\\uzli-nodal\\{analysis}\\15.txt" 1 all',
         "xyplot 1 donemenu",
         "deletewin 1",
@@ -46,7 +52,7 @@ def test_build_curve_commands_nodal():
 
 
 def test_build_curve_commands_custom_dirname():
-    analysis = AnalysisType.TIME_AXIAL_FORCE.value
+    analysis = AnalysisType.TIME_NODE_DISPLACEMENT_X.value
     cmds = build_curve_commands(
         base_project_dir="C:\\proj",
         top_folder_name="uzli-nodal",
@@ -56,7 +62,7 @@ def test_build_curve_commands_custom_dirname():
         element_id=15,
         analysis_dirname="1-custom",
     )
-    assert cmds[2] == (
+    assert cmds[3] == (
         'xyplot 1 savefile curve_file "C:\\proj\\curves\\uzli-nodal\\1-custom\\15.txt" 1 all'
     )
 
@@ -76,7 +82,7 @@ def test_build_curve_commands_invalid(kwargs):
     base_args = dict(
         base_project_dir="C:\\proj",
         top_folder_name="p-nodal",
-        analysis_type=AnalysisType.TIME_AXIAL_FORCE.value,
+        analysis_type=AnalysisType.TIME_NODE_DISPLACEMENT_X.value,
         entity_kind="nodal",
         element_type=None,
         element_id=1,
@@ -86,7 +92,9 @@ def test_build_curve_commands_invalid(kwargs):
         build_curve_commands(**base_args)
 
 
-@pytest.mark.parametrize("analysis, etime", ANALYSIS_TYPE_CODES["shell"].items())
+@pytest.mark.parametrize(
+    "analysis, etime", ANALYSIS_TYPE_CODES[("element", "shell")].items()
+)
 def test_build_curve_commands_shell(analysis, etime):
     etype = ETYPE_BY_ELEMENT["shell"]
     cmds = build_curve_commands(
@@ -106,8 +114,21 @@ def test_build_curve_commands_shell(analysis, etime):
 
 
 def test_analysis_type_codes_shell_updated():
-    codes = ANALYSIS_TYPE_CODES["shell"]
+    codes = ANALYSIS_TYPE_CODES[("element", "shell")]
     assert "Время - Изгибающий момент Mx(п)" in codes
     assert "Время - Изгибающий момент My(п)" in codes
     assert "Время - Изгибающий момент Mxy(п)" in codes
     assert "Время - Давление" in codes
+
+
+def test_build_global_curve_commands():
+    analysis = AnalysisType.TIME_GLOBAL_POTENTIAL_ENERGY.value
+    gtime = ANALYSIS_TYPE_CODES[("none", None)][analysis]
+    cmds = build_global_curve_commands(
+        base_project_dir="C:\\proj",
+        top_folder_name="global-none",
+        analysis_type=analysis,
+    )
+    assert cmds[0] == "genselect clear all"
+    assert cmds[1] == f"gtime {gtime}"
+    assert cmds[2].endswith(f"\\{analysis}\\{gtime}.txt\" 1 all")


### PR DESCRIPTION
## Summary
- add global and nodal analysis types and code mappings
- update the tab 4 tree UI and command builders to consume the new types and emit gtime/ntime commands
- extend automated tests to cover global and nodal workflows

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e36768a8c832aa0e78559cdc3c540)